### PR TITLE
Include license

### DIFF
--- a/recipe/LICENSE.txt
+++ b/recipe/LICENSE.txt
@@ -1,0 +1,13 @@
+BSD 3-clause license
+Copyright (c) conda-forge
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@
 {% set Y = 1 if variant == 'openblas' else 0 %}
 package:
   name: blas
-  version: 1.{{ Y }}
+  version: 2.{{ Y }}
 
 build:
   # We mustn't use the build number in the blas package - because we are defining the string,
@@ -30,6 +30,7 @@ test: {}
 about:
   home: https://github.com/conda-forge/blas-feedstock
   license: BSD 3-clause
+  license_file: {{ RECIPE_DIR if RECIPE_DIR is defined else '' }}/LICENSE.txt
   summary: Metapackage to select the BLAS variant. Use conda's pinning mechanism in your environment to control which variant you want.
 
 extra:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/blas-feedstock/issues/3

Adds the license file to the package. We need to do this because the BSD 3-Clause requires to include the license with all binary and source copies of this recipe/package.

~~As we are not actually changing any BLAS related package by adding more BLASes or changing the ordering of the BLASes, I think this is all we need to do as far as the stack is concerned.~~

Edit: The above statement is incorrect as we did pin the version number of this package in recipes. See this [example](https://github.com/conda-forge/numpy-feedstock/blob/4a7436d363562e8b9c9afa786f4456b0af39f060/recipe/meta.yaml#L30). Thus this would necessitate a total rebuild to include it. That being said, many of the BLAS dependent things are also missing licenses. So this would be a good opportunity to correct them too.
