### PR TITLE
remove track feature

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,17 +7,13 @@
 {% set Y = 1 if variant == 'openblas' else 0 %}
 package:
   name: blas
-  version: 1.{{ Y }}
+  version: 2.{{ Y }}
 
 build:
   # We mustn't use the build number in the blas package - because we are defining the string,
   # manually we would not be producing unique filenames.
   number: 0
   string: {{ variant }}
-  track_features:
-    # The "blas" package must always track a feature, else it will be
-    # prioritised over all others.
-    - blas_{{ variant }}
 
 {% if variant != "noblas" %}
 requirements:


### PR DESCRIPTION
Per discussion at https://github.com/conda/conda/issues/7626,

We believe that recent numpy issues where defaults numpy is being installed over conda-forge in ways that don't seem to respect channel priority are due to this track-feature leading conda to consider conda-forge's numpy as lower priority.

We believe that providing a blas metapackage without a track_feature will put conda-forge's numpy on equal footing with defaults, and channel-priority will then behave predictably.

CC @conda-forge/core