### PR TITLE
Update MKL pin to use conda-forge-pinning's mkl

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -6,7 +6,7 @@ jobs:
 - job: linux
   pool:
     vmImage: ubuntu-16.04
-  timeoutInMinutes: 240
+  timeoutInMinutes: 360
   strategy:
     maxParallel: 8
     matrix:
@@ -31,7 +31,7 @@ jobs:
       sudo pip install setuptools shyaml
     displayName: Install dependencies
 
-  # configure qemu binfmt-misc running.  This allows us to run docker containers 
+  # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |
       docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -6,7 +6,7 @@ jobs:
 - job: osx
   pool:
     vmImage: macOS-10.13
-  timeoutInMinutes: 240
+  timeoutInMinutes: 360
   strategy:
     maxParallel: 8
     matrix:
@@ -34,25 +34,18 @@ jobs:
       rm ~/uninstall_homebrew
     displayName: Remove homebrew
 
-  - script: |
-      echo "Installing Miniconda"
-      set -x -e
-      curl -o $(Build.StagingDirectory)/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
-      chmod +x $(Build.StagingDirectory)/miniconda.sh
-      $(Build.StagingDirectory)/miniconda.sh -b -p $(Build.StagingDirectory)/miniconda
-      export PATH=$(Build.StagingDirectory)/miniconda/bin:$PATH
-      echo "Setting up Conda environment"
-    displayName: 'Install miniconda'
+  - bash: |
+      echo "##vso[task.prependpath]$CONDA/bin"
+      sudo chown -R $USER $CONDA
+    displayName: Add conda to PATH
 
   - script: |
-      export PATH=$(Build.StagingDirectory)/miniconda/bin:$PATH
-      set -x -e
-      conda install -n base -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build
+      source activate base
+      conda install -n base -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build shyaml
     displayName: 'Add conda-forge-ci-setup=2'
 
   - script: |
-      set -x -e
-      export PATH=$(Build.StagingDirectory)/miniconda/bin:$PATH
+      source activate base
       echo "Configuring conda."
 
       setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
@@ -65,26 +58,22 @@ jobs:
     displayName: Configure conda and conda-build
 
   - script: |
-      export PATH=$(Build.StagingDirectory)/miniconda/bin:$PATH
-      set -x -e
+      source activate base
       mangle_compiler ./ ./recipe ./.ci_support/${CONFIG}.yaml
     displayName: Mangle compiler
 
   - script: |
-      export PATH=$(Build.StagingDirectory)/miniconda/bin:$PATH
-      set -x -e
+      source activate base
       make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
     displayName: Generate build number clobber file
 
   - script: |
-      export PATH=$(Build.StagingDirectory)/miniconda/bin:$PATH
-      set -x -e
+      source activate base
       conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
     displayName: Build recipe
 
   - script: |
-      export PATH=$(Build.StagingDirectory)/miniconda/bin:$PATH
-      set -x -e
+      source activate base
       upload_package ./ ./recipe ./.ci_support/${CONFIG}.yaml
     displayName: Upload recipe
     env:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -6,7 +6,7 @@ jobs:
 - job: win
   pool:
     vmImage: vs2017-win2016
-  timeoutInMinutes: 240
+  timeoutInMinutes: 360
   strategy:
     maxParallel: 4
     matrix:
@@ -73,7 +73,7 @@ jobs:
 
     # Configure the VM
     - script: setup_conda_rc .\ .\recipe .\.ci_support\%CONFIG%.yaml
-    
+
     # Configure the VM.
     - script: |
         run_conda_forge_build_setup

--- a/.ci_support/linux_blas_implblisblas_impl_libblis.yaml
+++ b/.ci_support/linux_blas_implblisblas_impl_libblis.yaml
@@ -18,6 +18,11 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+mkl:
+- '2019'
+pin_run_as_build:
+  mkl:
+    max_pin: x
 zip_keys:
 - - blas_impl
   - blas_impl_lib

--- a/.ci_support/linux_blas_implmklblas_impl_libmkl_rt.yaml
+++ b/.ci_support/linux_blas_implmklblas_impl_libmkl_rt.yaml
@@ -18,6 +18,11 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+mkl:
+- '2019'
+pin_run_as_build:
+  mkl:
+    max_pin: x
 zip_keys:
 - - blas_impl
   - blas_impl_lib

--- a/.ci_support/linux_blas_implopenblasblas_impl_libopenblas.yaml
+++ b/.ci_support/linux_blas_implopenblasblas_impl_libopenblas.yaml
@@ -18,6 +18,11 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+mkl:
+- '2019'
+pin_run_as_build:
+  mkl:
+    max_pin: x
 zip_keys:
 - - blas_impl
   - blas_impl_lib

--- a/.ci_support/osx_blas_implblisblas_impl_libblis.yaml
+++ b/.ci_support/osx_blas_implblisblas_impl_libblis.yaml
@@ -22,6 +22,11 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
+mkl:
+- '2019'
+pin_run_as_build:
+  mkl:
+    max_pin: x
 zip_keys:
 - - blas_impl
   - blas_impl_lib

--- a/.ci_support/osx_blas_implmklblas_impl_libmkl_rt.yaml
+++ b/.ci_support/osx_blas_implmklblas_impl_libmkl_rt.yaml
@@ -22,6 +22,11 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
+mkl:
+- '2019'
+pin_run_as_build:
+  mkl:
+    max_pin: x
 zip_keys:
 - - blas_impl
   - blas_impl_lib

--- a/.ci_support/osx_blas_implopenblasblas_impl_libopenblas.yaml
+++ b/.ci_support/osx_blas_implopenblasblas_impl_libopenblas.yaml
@@ -22,6 +22,11 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
+mkl:
+- '2019'
+pin_run_as_build:
+  mkl:
+    max_pin: x
 zip_keys:
 - - blas_impl
   - blas_impl_lib

--- a/.ci_support/win_blas_implblisblas_impl_liblibblis.2.yaml
+++ b/.ci_support/win_blas_implblisblas_impl_liblibblis.2.yaml
@@ -12,6 +12,11 @@ m2w64_c_compiler:
 - m2w64-toolchain
 m2w64_fortran_compiler:
 - m2w64-toolchain
+mkl:
+- '2019'
+pin_run_as_build:
+  mkl:
+    max_pin: x
 zip_keys:
 - - blas_impl
   - blas_impl_lib

--- a/.ci_support/win_blas_implmklblas_impl_libmkl_rt.yaml
+++ b/.ci_support/win_blas_implmklblas_impl_libmkl_rt.yaml
@@ -12,6 +12,11 @@ m2w64_c_compiler:
 - m2w64-toolchain
 m2w64_fortran_compiler:
 - m2w64-toolchain
+mkl:
+- '2019'
+pin_run_as_build:
+  mkl:
+    max_pin: x
 zip_keys:
 - - blas_impl
   - blas_impl_lib

--- a/.ci_support/win_blas_implopenblasblas_impl_libopenblas.yaml
+++ b/.ci_support/win_blas_implopenblasblas_impl_libopenblas.yaml
@@ -12,6 +12,11 @@ m2w64_c_compiler:
 - m2w64-toolchain
 m2w64_fortran_compiler:
 - m2w64-toolchain
+mkl:
+- '2019'
+pin_run_as_build:
+  mkl:
+    max_pin: x
 zip_keys:
 - - blas_impl
   - blas_impl_lib

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Checklist
 * [ ] Used a fork of the feedstock to propose changes
 * [ ] Bumped the build number (if the version is unchanged)
 * [ ] Reset the build number to `0` (if the version changed)
-* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
+* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
 * [ ] Ensured the license file is being packaged.
 
 <!--

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2018, conda-forge
+Copyright (c) 2015-2019, conda-forge
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-<!--
-# -*- mode: jinja -*-
--->
-
 About blas-split
 ================
 
@@ -18,7 +14,111 @@ Summary: Metapackage to select the BLAS variant. Use conda's pinning mechanism i
 Current build status
 ====================
 
-[![Windows](https://img.shields.io/appveyor/ci/conda-forge/blas-feedstock/master.svg?label=Windows)](https://ci.appveyor.com/project/conda-forge/blas-feedstock/branch/master)
+
+<table><tr>
+    <td>Appveyor</td>
+    <td>
+      <a href="https://ci.appveyor.com/project/conda-forge/blas-feedstock/branch/master">
+        <img alt="windows" src="https://img.shields.io/appveyor/ci/conda-forge/blas-feedstock/master.svg?label=Windows">
+      </a>
+    </td>
+  </tr>
+    
+  <tr>
+    <td>Azure</td>
+    <td>
+      <details>
+        <summary>
+          <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3701&branchName=master">
+            <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/blas-feedstock?branchName=master">
+          </a>
+        </summary>
+        <table>
+          <thead><tr><th>Variant</th><th>Status</th></tr></thead>
+          <tbody><tr>
+              <td>linux_aarch64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3701&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/blas-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_blas_implblisblas_impl_libblis</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3701&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/blas-feedstock?branchName=master&jobName=linux&configuration=linux_blas_implblisblas_impl_libblis" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_blas_implmklblas_impl_libmkl_rt</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3701&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/blas-feedstock?branchName=master&jobName=linux&configuration=linux_blas_implmklblas_impl_libmkl_rt" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_blas_implopenblasblas_impl_libopenblas</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3701&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/blas-feedstock?branchName=master&jobName=linux&configuration=linux_blas_implopenblasblas_impl_libopenblas" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3701&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/blas-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_blas_implblisblas_impl_libblis</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3701&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/blas-feedstock?branchName=master&jobName=osx&configuration=osx_blas_implblisblas_impl_libblis" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_blas_implmklblas_impl_libmkl_rt</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3701&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/blas-feedstock?branchName=master&jobName=osx&configuration=osx_blas_implmklblas_impl_libmkl_rt" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_blas_implopenblasblas_impl_libopenblas</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3701&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/blas-feedstock?branchName=master&jobName=osx&configuration=osx_blas_implopenblasblas_impl_libopenblas" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_blas_implblisblas_impl_liblibblis.2</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3701&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/blas-feedstock?branchName=master&jobName=win&configuration=win_blas_implblisblas_impl_liblibblis.2" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_blas_implmklblas_impl_libmkl_rt</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3701&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/blas-feedstock?branchName=master&jobName=win&configuration=win_blas_implmklblas_impl_libmkl_rt" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_blas_implopenblasblas_impl_libopenblas</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=3701&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/blas-feedstock?branchName=master&jobName=win&configuration=win_blas_implopenblasblas_impl_libopenblas" alt="variant">
+                </a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </details>
+    </td>
+  </tr>
+</table>
 
 Current release info
 ====================

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,11 +42,11 @@ outputs:
     requirements:
       host:
         - openblas 0.3.5   # [blas_impl == 'openblas']
-        - mkl {{ mkl }}    # [blas_impl == 'mkl']
+        - mkl 2019.0       # [blas_impl == 'mkl']
         - blis 0.5.1       # [blas_impl == 'blis']
       run:
         - openblas 0.3.5   # [blas_impl == 'openblas']
-        - mkl {{ mkl }}    # [blas_impl == 'mkl']
+        - {{ pin_compatible("mkl") }}    # [blas_impl == 'mkl']
         - blis 0.5.1       # [blas_impl == 'blis']
       run_constrained:
         - {{ pin_subpackage("libcblas", exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.8.0" %}
-{% set build_num = "4" %}
+{% set build_num = "5" %}
 {% set version_major = version.split(".")[0] %}
 {% set blas_major = "2" %}
 
@@ -42,11 +42,11 @@ outputs:
     requirements:
       host:
         - openblas 0.3.5   # [blas_impl == 'openblas']
-        - mkl 2019.1       # [blas_impl == 'mkl']
+        - mkl {{ mkl }}    # [blas_impl == 'mkl']
         - blis 0.5.1       # [blas_impl == 'blis']
       run:
         - openblas 0.3.5   # [blas_impl == 'openblas']
-        - mkl 2019.1       # [blas_impl == 'mkl']
+        - mkl {{ mkl }}    # [blas_impl == 'mkl']
         - blis 0.5.1       # [blas_impl == 'blis']
       run_constrained:
         - {{ pin_subpackage("libcblas", exact=True) }}


### PR DESCRIPTION
This PR updates the recipe to pin `mkl` to `{{ mkl }}`, ideally bringing it inline with other CF packages building against `mkl`.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
