### PR TITLE
Revert #38 (Move symlinks back into libblas)

### DIFF
--- a/recipe/build_pkg.sh
+++ b/recipe/build_pkg.sh
@@ -3,6 +3,7 @@ if [[ "$target_platform" == "osx-64" ]]; then
 else
     ln -s $PREFIX/lib/${blas_impl_lib} $PREFIX/lib/${PKG_NAME}.so.${PKG_VERSION:0:1}
 fi
+ln -s $PREFIX/lib/${blas_impl_lib} $PREFIX/lib/${PKG_NAME}${SHLIB_EXT}
 
 if [[ "${blas_impl}" == "mkl" ]]; then
     for CHANGE in "activate" "deactivate"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -200,6 +200,13 @@ outputs:
         - test -f $PREFIX/lib/liblapacke.{{ version_major }}.dylib   # [osx]
         - if not exist %LIBRARY_BIN%/liblapacke.dll exit 1           # [win]
 
+  - name: blas-devel
+    requirements:
+      run:
+        - openblas   # [blas_impl == "openblas"]
+        - mkl-devel  # [blas_impl == "mkl"]
+        - blas {{ version }} *{{blas_impl}}
+
 about:
   home: https://github.com/conda-forge/blas-feedstock
   license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.8.0" %}
-{% set build_num = "13" %}
+{% set build_num = "14" %}
 {% set version_major = version.split(".")[0] %}
 {% set blas_major = "2" %}
 
@@ -55,6 +55,8 @@ outputs:
         - {{ pin_subpackage("liblapacke", exact=True) }}   # [blas_impl != 'blis']
         - blas * {{ blas_impl }}
     files:
+      - lib/libblas.so                          # [linux]
+      - lib/libblas.dylib                       # [osx]
       - lib/libblas.so.{{ version_major }}      # [linux]
       - lib/libblas.{{ version_major }}.dylib   # [osx]
       - Library/bin/libblas.dll                 # [win]
@@ -62,7 +64,6 @@ outputs:
       commands:
         # Following line is just to help conda-build's used variables detection
         - echo hello  # [blas_impl_lib == 'blas']
-        - test ! -f $PREFIX/lib/libblas${SHLIB_EXT}               # [unix]
         - test -f $PREFIX/lib/libblas.so.{{ version_major }}      # [linux]
         - test -f $PREFIX/lib/libblas.{{ version_major }}.dylib   # [osx]
         - if not exist %LIBRARY_BIN%/libblas.dll exit 1           # [win]
@@ -86,12 +87,13 @@ outputs:
         - {{ pin_subpackage("liblapacke", exact=True) }}   # [blas_impl != 'blis']
         - blas * {{ blas_impl }}
     files:
+      - lib/libcblas.so                          # [linux]
+      - lib/libcblas.dylib                       # [osx]
       - lib/libcblas.so.{{ version_major }}      # [linux]
       - lib/libcblas.{{ version_major }}.dylib   # [osx]
       - Library/bin/libcblas.dll                 # [win]
     test:
       commands:
-        - test ! -f $PREFIX/lib/libcblas${SHLIB_EXT}               # [unix]
         - test -f $PREFIX/lib/libcblas.so.{{ version_major }}      # [linux]
         - test -f $PREFIX/lib/libcblas.{{ version_major }}.dylib   # [osx]
         - if not exist %LIBRARY_BIN%/libcblas.dll exit 1           # [win]
@@ -116,12 +118,13 @@ outputs:
         - {{ pin_subpackage("liblapacke", exact=True) }}
         - blas * {{ blas_impl }}
     files:
+      - lib/liblapack.so                          # [linux]
+      - lib/liblapack.dylib                       # [osx]
       - lib/liblapack.so.{{ version_major }}      # [linux]
       - lib/liblapack.{{ version_major }}.dylib   # [osx]
       - Library/bin/liblapack.dll                 # [win]
     test:
       commands:
-        - test ! -f $PREFIX/lib/liblapack${SHLIB_EXT}               # [unix]
         - test -f $PREFIX/lib/liblapack.so.{{ version_major }}      # [linux]
         - test -f $PREFIX/lib/liblapack.{{ version_major }}.dylib   # [osx]
         - if not exist %LIBRARY_BIN%/liblapack.dll exit 1           # [win]
@@ -147,12 +150,13 @@ outputs:
       run_constrained:
         - blas * {{ blas_impl }}
     files:
+      - lib/liblapacke.so                          # [linux]
+      - lib/liblapacke.dylib                       # [osx]
       - lib/liblapacke.so.{{ version_major }}      # [linux]
       - lib/liblapacke.{{ version_major }}.dylib   # [osx]
       - Library/bin/liblapacke.dll                 # [win]
     test:
       commands:
-        - test ! -f $PREFIX/lib/liblapacke${SHLIB_EXT}               # [unix]
         - test -f $PREFIX/lib/liblapacke.so.{{ version_major }}      # [linux]
         - test -f $PREFIX/lib/liblapacke.{{ version_major }}.dylib   # [osx]
         - if not exist %LIBRARY_BIN%/liblapacke.dll exit 1           # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -209,7 +209,7 @@ outputs:
       run:
         - openblas   # [blas_impl == "openblas"]
         - mkl-devel  # [blas_impl == "mkl"]
-        - blas {{ version }} *{{blas_impl}}
+        - {{ pin_subpackage("blas", exact=True) }}
 
 about:
   home: https://github.com/conda-forge/blas-feedstock

--- a/recipe/test_blas.sh
+++ b/recipe/test_blas.sh
@@ -1,14 +1,6 @@
 #!/bin/bash
 set -e
 
-# Setup symlinks for .so and .dylib
-
-if [[ "$target_platform" != win* ]]; then
-  for pkg in blas cblas lapack lapacke; do
-    ln -s $PREFIX/lib/${blas_impl_lib} $PREFIX/lib/lib${pkg}${SHLIB_EXT}
-  done
-fi
-
 cd build
 
 SKIP_TESTS="dummy"


### PR DESCRIPTION
cc @minrk, @SylvainCorlay 

Adds a `blas-devel` package as suggested by @minrk and restoring symlinks in libblas for now.