### PR TITLE
Rebuild to pick up conda-forge/blis-feedstock#21

### DIFF
--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -11,7 +11,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 fortran_compiler:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "3.9.0" %}
 # if build_num is reset to 0 (for new version), update increment for blas_minor below
-{% set build_num = 5 %}
+{% set build_num = 6 %}
 {% set version_major = version.split(".")[0] %}
 {% set blas_major = "2" %}
 # make sure we do not create colliding version strings of output "blas"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -252,3 +252,4 @@ extra:
     - pelson
     - isuruf
     - ocefpaf
+    - h-vetinari


### PR DESCRIPTION
@isuruf 

`blas` build 105 pulled in `win-64::blis-0.8.0-h8d14728_0` (instead of the builds from conda-forge/blis-feedstock#21), and since the pin in `libblas` is exact, we need another rebuild to get the correct blis build (windows + blis is still failing with the same error in https://github.com/conda-forge/scipy-feedstock/pull/153)