### PR TITLE
build for MKL 2025.0

### DIFF
--- a/.ci_support/linux_64_blas_implblisblas_impl_liblibblis.so.4.yaml
+++ b/.ci_support/linux_64_blas_implblisblas_impl_liblibblis.so.4.yaml
@@ -15,7 +15,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -33,5 +33,3 @@ zip_keys:
   - blas_impl_lib
 - - c_compiler_version
   - fortran_compiler_version
-- - c_stdlib_version
-  - cdt_name

--- a/.ci_support/linux_64_blas_implmklblas_impl_liblibmkl_rt.so.yaml
+++ b/.ci_support/linux_64_blas_implmklblas_impl_liblibmkl_rt.so.yaml
@@ -15,7 +15,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -33,5 +33,3 @@ zip_keys:
   - blas_impl_lib
 - - c_compiler_version
   - fortran_compiler_version
-- - c_stdlib_version
-  - cdt_name

--- a/.ci_support/linux_64_blas_implopenblasblas_impl_liblibopenblas.so.0.yaml
+++ b/.ci_support/linux_64_blas_implopenblasblas_impl_liblibopenblas.so.0.yaml
@@ -15,7 +15,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -33,5 +33,3 @@ zip_keys:
   - blas_impl_lib
 - - c_compiler_version
   - fortran_compiler_version
-- - c_stdlib_version
-  - cdt_name

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -19,7 +19,7 @@ c_stdlib_version:
 cdt_arch:
 - aarch64
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -37,5 +37,3 @@ zip_keys:
   - blas_impl_lib
 - - c_compiler_version
   - fortran_compiler_version
-- - c_stdlib_version
-  - cdt_name

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -15,7 +15,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -33,5 +33,3 @@ zip_keys:
   - blas_impl_lib
 - - c_compiler_version
   - fortran_compiler_version
-- - c_stdlib_version
-  - cdt_name

--- a/.ci_support/osx_64_blas_implaccelerateblas_impl_liblibvecLibFort-ng.dylib.yaml
+++ b/.ci_support/osx_64_blas_implaccelerateblas_impl_liblibvecLibFort-ng.dylib.yaml
@@ -13,7 +13,7 @@ blas_impl_lib:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:

--- a/.ci_support/osx_64_blas_implblisblas_impl_liblibblis.4.dylib.yaml
+++ b/.ci_support/osx_64_blas_implblisblas_impl_liblibblis.4.dylib.yaml
@@ -13,7 +13,7 @@ blas_impl_lib:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:

--- a/.ci_support/osx_64_blas_implopenblasblas_impl_liblibopenblas.0.dylib.yaml
+++ b/.ci_support/osx_64_blas_implopenblasblas_impl_liblibopenblas.0.dylib.yaml
@@ -13,7 +13,7 @@ blas_impl_lib:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:

--- a/.ci_support/osx_arm64_blas_implaccelerateblas_impl_liblibvecLibFort-ng.dylib.yaml
+++ b/.ci_support/osx_arm64_blas_implaccelerateblas_impl_liblibvecLibFort-ng.dylib.yaml
@@ -13,7 +13,7 @@ blas_impl_lib:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:

--- a/.ci_support/osx_arm64_blas_implopenblasblas_impl_liblibopenblas.0.dylib.yaml
+++ b/.ci_support/osx_arm64_blas_implopenblasblas_impl_liblibopenblas.0.dylib.yaml
@@ -13,7 +13,7 @@ blas_impl_lib:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -33,7 +33,7 @@ rm -rf "${MAMBA_ROOT_PREFIX}" "${micromamba_exe}" || true
 ( endgroup "Provisioning base env with micromamba" ) 2> /dev/null
 
 ( startgroup "Configuring conda" ) 2> /dev/null
-
+echo "Activating environment"
 source "${MINIFORGE_HOME}/etc/profile.d/conda.sh"
 conda activate base
 export CONDA_SOLVER="libmamba"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -12,6 +12,7 @@
 
 setlocal enableextensions enabledelayedexpansion
 
+FOR %%A IN ("%~dp0.") DO SET "REPO_ROOT=%%~dpA"
 if "%MINIFORGE_HOME%"=="" set "MINIFORGE_HOME=%USERPROFILE%\Miniforge3"
 :: Remove trailing backslash, if present
 if "%MINIFORGE_HOME:~-1%"=="\" set "MINIFORGE_HOME=%MINIFORGE_HOME:~0,-1%"
@@ -32,17 +33,14 @@ call "%MICROMAMBA_EXE%" create --yes --root-prefix "%MAMBA_ROOT_PREFIX%" --prefi
     --channel conda-forge ^
     pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 if !errorlevel! neq 0 exit /b !errorlevel!
-echo Moving pkgs cache from %MAMBA_ROOT_PREFIX% to %MINIFORGE_HOME%
-move /Y "%MAMBA_ROOT_PREFIX%\pkgs" "%MINIFORGE_HOME%"
-if !errorlevel! neq 0 exit /b !errorlevel!
 echo Removing %MAMBA_ROOT_PREFIX%
 del /S /Q "%MAMBA_ROOT_PREFIX%"
 del /S /Q "%MICROMAMBA_TMPDIR%"
-call :end_group
 
 call :start_group "Configuring conda"
 
 :: Activate the base conda environment
+echo Activating environment
 call "%MINIFORGE_HOME%\Scripts\activate.bat"
 :: Configure the solver
 set "CONDA_SOLVER=libmamba"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ stages:
           echo "##vso[task.setvariable variable=log]$git_log"
         displayName: Obtain commit message
       - bash: echo "##vso[task.setvariable variable=RET]false"
-        condition: or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]'))
+        condition: and(eq(variables['Build.Reason'], 'PullRequest'), or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]')))
         displayName: Skip build?
       - bash: echo "##vso[task.setvariable variable=start_main;isOutput=true]$RET"
         name: result

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "3.9.0" %}
 # if build_num is reset to 0 (for new version), update increment for blas_minor below
-{% set build_num = 25 %}
+{% set build_num = 26 %}
 {% set version_major = version.split(".")[0] %}
 # blas_major denotes major infrastructural change to how blas is managed
 {% set blas_major = "2" %}
@@ -75,7 +75,7 @@ outputs:
       host:
         - libopenblas 0.3.28   # [blas_impl == 'openblas']
         # from https://github.com/conda-forge/intel_repack-feedstock/
-        - mkl 2024.2           # [blas_impl == 'mkl']
+        - mkl 2025.0           # [blas_impl == 'mkl']
         - blis 0.9.0           # [blas_impl == 'blis']
       run:
         - {{ pin_compatible("libopenblas", max_pin="x.x.x", exact=win) }}  # [blas_impl == 'openblas']
@@ -207,10 +207,10 @@ outputs:
     requirements:
       host:
         - openblas   0.3.28  # [blas_impl == "openblas"]
-        - mkl-devel  2024.2  # [blas_impl == "mkl"]
+        - mkl-devel  2025.0  # [blas_impl == "mkl"]
       run:
         - openblas   0.3.28  # [blas_impl == "openblas"]
-        - mkl-devel  2024.2  # [blas_impl == "mkl"]
+        - mkl-devel  2025.0  # [blas_impl == "mkl"]
         - {{ pin_subpackage("liblapack", exact=True) }}      # [blas_impl != 'blis']
         - {{ pin_subpackage("liblapacke", exact=True) }}     # [blas_impl != 'blis']
         - liblapack  {{ version }} *netlib                   # [blas_impl == 'blis']


### PR DESCRIPTION
Not having this pushes the solver into weird contortions like
```diff
  - libblas                            3.9.0  25_win64_mkl           conda-forge        4MB
  + libblas                            3.9.0  25_win64_openblas      conda-forge        4MB
  - libcblas                           3.9.0  25_win64_mkl           conda-forge        4MB
  + libcblas                           3.9.0  25_win64_openblas      conda-forge        4MB
  - liblapack                          3.9.0  25_win64_mkl           conda-forge        4MB
  + liblapack                          3.9.0  25_win64_openblas      conda-forge        4MB
```
because it ends up prioritizing the newer MKL; apparently despite the `track_features` on the non-default BLAS impl here.

We might want to add more track_features here?