### PR TITLE
Distinguish pthreads & openmp variants in build strings for openblas on windows

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,23 +11,23 @@ jobs:
       linux_64_blas_implblisblas_impl_liblibblis.so.4:
         CONFIG: linux_64_blas_implblisblas_impl_liblibblis.so.4
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_64_blas_implmklblas_impl_liblibmkl_rt.so:
         CONFIG: linux_64_blas_implmklblas_impl_liblibmkl_rt.so
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_64_blas_implopenblasblas_impl_liblibopenblas.so.0:
         CONFIG: linux_64_blas_implopenblasblas_impl_liblibopenblas.so.0
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_:
         CONFIG: linux_aarch64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_ppc64le_:
         CONFIG: linux_ppc64le_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -33,6 +33,7 @@ jobs:
       displayName: Run Windows build
       env:
         MINIFORGE_HOME: $(MINIFORGE_HOME)
+        CONDA_BLD_PATH: $(CONDA_BLD_PATH)
         PYTHONUNBUFFERED: 1
         CONFIG: $(CONFIG)
         CI: azure

--- a/.ci_support/linux_64_blas_implblisblas_impl_liblibblis.so.4.yaml
+++ b/.ci_support/linux_64_blas_implblisblas_impl_liblibblis.so.4.yaml
@@ -1,5 +1,3 @@
-ace:
-- 8.0.1
 blas_default_impl:
 - openblas
 blas_impl:
@@ -21,11 +19,23 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
+mkl:
+- '2023'
+openblas:
+- 0.3.*
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_blas_implmklblas_impl_liblibmkl_rt.so.yaml
+++ b/.ci_support/linux_64_blas_implmklblas_impl_liblibmkl_rt.so.yaml
@@ -1,5 +1,3 @@
-ace:
-- 8.0.1
 blas_default_impl:
 - openblas
 blas_impl:
@@ -21,11 +19,23 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
+mkl:
+- '2023'
+openblas:
+- 0.3.*
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_blas_implopenblasblas_impl_liblibopenblas.so.0.yaml
+++ b/.ci_support/linux_64_blas_implopenblasblas_impl_liblibopenblas.so.0.yaml
@@ -1,5 +1,3 @@
-ace:
-- 8.0.1
 blas_default_impl:
 - openblas
 blas_impl:
@@ -21,11 +19,23 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
+mkl:
+- '2023'
+openblas:
+- 0.3.*
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,7 +1,3 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
-ace:
-- 8.0.1
 blas_default_impl:
 - openblas
 blas_impl:
@@ -16,8 +12,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_arch:
-- aarch64
 cdt_name:
 - conda
 channel_sources:
@@ -25,11 +19,21 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
+openblas:
+- 0.3.*
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,5 +1,3 @@
-ace:
-- 8.0.1
 blas_default_impl:
 - openblas
 blas_impl:
@@ -21,11 +19,21 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
+openblas:
+- 0.3.*
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/osx_64_blas_implaccelerateblas_impl_liblibvecLibFort-ng.dylib.yaml
+++ b/.ci_support/osx_64_blas_implaccelerateblas_impl_liblibvecLibFort-ng.dylib.yaml
@@ -2,8 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.13'
 MACOSX_SDK_VERSION:
 - '10.13'
-ace:
-- 8.0.1
 blas_default_impl:
 - openblas
 blas_impl:
@@ -26,8 +24,18 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
+openblas:
+- 0.3.*
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blas_implblisblas_impl_liblibblis.4.dylib.yaml
+++ b/.ci_support/osx_64_blas_implblisblas_impl_liblibblis.4.dylib.yaml
@@ -2,8 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.13'
 MACOSX_SDK_VERSION:
 - '10.13'
-ace:
-- 8.0.1
 blas_default_impl:
 - openblas
 blas_impl:
@@ -26,8 +24,18 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
+openblas:
+- 0.3.*
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blas_implopenblasblas_impl_liblibopenblas.0.dylib.yaml
+++ b/.ci_support/osx_64_blas_implopenblasblas_impl_liblibopenblas.0.dylib.yaml
@@ -2,8 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.13'
 MACOSX_SDK_VERSION:
 - '10.13'
-ace:
-- 8.0.1
 blas_default_impl:
 - openblas
 blas_impl:
@@ -26,8 +24,18 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
+openblas:
+- 0.3.*
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_arm64_blas_implaccelerateblas_impl_liblibvecLibFort-ng.dylib.yaml
+++ b/.ci_support/osx_arm64_blas_implaccelerateblas_impl_liblibvecLibFort-ng.dylib.yaml
@@ -2,8 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
-ace:
-- 8.0.1
 blas_default_impl:
 - openblas
 blas_impl:
@@ -26,8 +24,18 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
 macos_machine:
 - arm64-apple-darwin20.0.0
+openblas:
+- 0.3.*
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_blas_implopenblasblas_impl_liblibopenblas.0.dylib.yaml
+++ b/.ci_support/osx_arm64_blas_implopenblasblas_impl_liblibopenblas.0.dylib.yaml
@@ -2,8 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
-ace:
-- 8.0.1
 blas_default_impl:
 - openblas
 blas_impl:
@@ -26,8 +24,18 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
 macos_machine:
 - arm64-apple-darwin20.0.0
+openblas:
+- 0.3.*
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/win_64_blas_implblisblas_impl_liblibblis.4.dllopenblas_typedummy.yaml
+++ b/.ci_support/win_64_blas_implblisblas_impl_liblibblis.4.dllopenblas_typedummy.yaml
@@ -1,5 +1,3 @@
-ace:
-- 8.0.1
 blas_default_impl:
 - mkl
 blas_impl:
@@ -18,6 +16,16 @@ fortran_compiler:
 - flang
 fortran_compiler_version:
 - '19'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
+mkl:
+- '2023'
 openblas:
 - 0.3.*
 openblas_type:

--- a/.ci_support/win_64_blas_implmklblas_impl_libmkl_rt.2.dllopenblas_typedummy.yaml
+++ b/.ci_support/win_64_blas_implmklblas_impl_libmkl_rt.2.dllopenblas_typedummy.yaml
@@ -1,5 +1,3 @@
-ace:
-- 8.0.1
 blas_default_impl:
 - mkl
 blas_impl:
@@ -18,6 +16,16 @@ fortran_compiler:
 - flang
 fortran_compiler_version:
 - '19'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
+mkl:
+- '2023'
 openblas:
 - 0.3.*
 openblas_type:

--- a/.ci_support/win_64_blas_implopenblasblas_impl_libopenblas.dllopenblas_typeopenmp.yaml
+++ b/.ci_support/win_64_blas_implopenblasblas_impl_libopenblas.dllopenblas_typeopenmp.yaml
@@ -1,5 +1,3 @@
-ace:
-- 8.0.1
 blas_default_impl:
 - mkl
 blas_impl:
@@ -18,6 +16,16 @@ fortran_compiler:
 - flang
 fortran_compiler_version:
 - '19'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
+mkl:
+- '2023'
 openblas:
 - 0.3.*
 openblas_type:

--- a/.ci_support/win_64_blas_implopenblasblas_impl_libopenblas.dllopenblas_typepthreads.yaml
+++ b/.ci_support/win_64_blas_implopenblasblas_impl_libopenblas.dllopenblas_typepthreads.yaml
@@ -1,5 +1,3 @@
-ace:
-- 8.0.1
 blas_default_impl:
 - mkl
 blas_impl:
@@ -18,6 +16,16 @@ fortran_compiler:
 - flang
 fortran_compiler_version:
 - '19'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
+mkl:
+- '2023'
 openblas:
 - 0.3.*
 openblas_type:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -35,7 +35,7 @@ mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-
 echo > /opt/conda/conda-meta/history
 micromamba install --root-prefix ~/.conda --prefix /opt/conda \
     --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.11"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -6,8 +6,9 @@ source .scripts/logging_utils.sh
 
 set -xe
 
-MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
-MINIFORGE_HOME=${MINIFORGE_HOME%/} # remove trailing slash
+MINIFORGE_HOME="${MINIFORGE_HOME:-${HOME}/miniforge3}"
+MINIFORGE_HOME="${MINIFORGE_HOME%/}" # remove trailing slash
+export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${MINIFORGE_HOME}/conda-bld}"
 
 ( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
 MICROMAMBA_VERSION="1.5.10-0"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -26,7 +26,7 @@ chmod +x "${micromamba_exe}"
 echo "Creating environment"
 "${micromamba_exe}" create --yes --root-prefix "${MAMBA_ROOT_PREFIX}" --prefix "${MINIFORGE_HOME}" \
   --channel conda-forge \
-  pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+  pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.11"
 echo "Moving pkgs cache from ${MAMBA_ROOT_PREFIX} to ${MINIFORGE_HOME}"
 mv "${MAMBA_ROOT_PREFIX}/pkgs" "${MINIFORGE_HOME}"
 echo "Cleaning up micromamba"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -36,6 +36,7 @@ if !errorlevel! neq 0 exit /b !errorlevel!
 echo Removing %MAMBA_ROOT_PREFIX%
 del /S /Q "%MAMBA_ROOT_PREFIX%" >nul
 del /S /Q "%MICROMAMBA_TMPDIR%" >nul
+call :end_group
 
 call :start_group "Configuring conda"
 

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -31,7 +31,7 @@ if !errorlevel! neq 0 exit /b !errorlevel!
 echo Creating environment
 call "%MICROMAMBA_EXE%" create --yes --root-prefix "%MAMBA_ROOT_PREFIX%" --prefix "%MINIFORGE_HOME%" ^
     --channel conda-forge ^
-    pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+    pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.11"
 if !errorlevel! neq 0 exit /b !errorlevel!
 echo Removing %MAMBA_ROOT_PREFIX%
 del /S /Q "%MAMBA_ROOT_PREFIX%" >nul

--- a/build-locally.py
+++ b/build-locally.py
@@ -26,6 +26,13 @@ def setup_environment(ns):
             os.path.dirname(__file__), "miniforge3"
         )
 
+    # The default cache location might not be writable using docker on macOS.
+    if ns.config.startswith("linux") and platform.system() == "Darwin":
+        os.environ["CONDA_FORGE_DOCKER_RUN_ARGS"] = (
+            os.environ.get("CONDA_FORGE_DOCKER_RUN_ARGS", "")
+            + " -e RATTLER_CACHE_DIR=/tmp/rattler_cache"
+        )
+
 
 def run_docker_build(ns):
     script = ".scripts/run_docker_build.sh"

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -11,7 +11,7 @@ github:
 provider:
   linux_aarch64: default
   linux_ppc64le: default
-remote_ci_config:
+remote_ci_setup:
   - conda-forge-ci-setup=4
   - conda-build>=24.11
 test: native_and_emulated

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -11,4 +11,7 @@ github:
 provider:
   linux_aarch64: default
   linux_ppc64le: default
+remote_ci_config:
+  - conda-forge-ci-setup=4
+  - conda-build>=24.11
 test: native_and_emulated

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,7 +87,7 @@ outputs:
         - libcblas ={{ version }}={{ build_num }}*_{{ blas_impl }}
         - liblapack ={{ version }}={{ build_num }}*_{{ blas_impl }}     # [blas_impl != 'blis']
         - liblapacke ={{ version }}={{ build_num }}*_{{ blas_impl }}    # [blas_impl != 'blis']
-        - blas * {{ blas_impl }}
+        - blas =*={{ blas_impl }}
     files:
       - lib/libblas.so                          # [linux]
       - lib/libblas.dylib                       # [osx]
@@ -126,7 +126,7 @@ outputs:
         # cannot pin exactly due to conda-build bug with nonsense hash in run_constrained
         - liblapack ={{ version }}={{ build_num }}*_{{ blas_impl }}     # [blas_impl != 'blis']
         - liblapacke ={{ version }}={{ build_num }}*_{{ blas_impl }}    # [blas_impl != 'blis']
-        - blas * {{ blas_impl }}
+        - blas =*={{ blas_impl }}
     files:
       - lib/libcblas.so                          # [linux]
       - lib/libcblas.dylib                       # [osx]
@@ -159,7 +159,7 @@ outputs:
         # cannot pin exactly due to conda-build bug with nonsense hash in run_constrained
         - libcblas ={{ version }}={{ build_num }}*_{{ blas_impl }}
         - liblapacke ={{ version }}={{ build_num }}*_{{ blas_impl }}
-        - blas * {{ blas_impl }}
+        - blas =*={{ blas_impl }}
     files:
       - lib/liblapack.so                          # [linux]
       - lib/liblapack.dylib                       # [osx]
@@ -192,7 +192,7 @@ outputs:
         - {{ pin_subpackage("libcblas", exact=True) }}
         - {{ pin_subpackage("liblapack", exact=True) }}
       run_constrained:
-        - blas * {{ blas_impl }}
+        - blas =*={{ blas_impl }}
     files:
       - lib/liblapacke.so                          # [linux]
       - lib/liblapacke.dylib                       # [osx]
@@ -221,8 +221,8 @@ outputs:
         - mkl-devel  2024.2  # [blas_impl == "mkl"]
         - {{ pin_subpackage("liblapack", exact=True) }}      # [blas_impl != 'blis']
         - {{ pin_subpackage("liblapacke", exact=True) }}     # [blas_impl != 'blis']
-        - liblapack  {{ version }} *netlib                   # [blas_impl == 'blis']
-        - liblapacke {{ version }} *netlib                   # [blas_impl == 'blis']
+        - liblapack  ={{ version }}=*netlib                  # [blas_impl == 'blis']
+        - liblapacke ={{ version }}=*netlib                  # [blas_impl == 'blis']
         - {{ pin_subpackage("libcblas", exact=True) }}
         - {{ pin_subpackage("libblas", exact=True) }}
     test:
@@ -239,7 +239,7 @@ outputs:
     script: test_blas.sh   # [unix]
     script: test_blas.bat  # [win]
     build:
-      string: {{ blas_impl }}
+      string: "{{ blas_impl }}"
       activate_in_script: True
     requirements:
       build:
@@ -268,8 +268,8 @@ outputs:
       run:
         - {{ pin_subpackage("liblapack", exact=True) }}      # [blas_impl != 'blis']
         - {{ pin_subpackage("liblapacke", exact=True) }}     # [blas_impl != 'blis']
-        - liblapack  {{ version }} *netlib                   # [blas_impl == 'blis']
-        - liblapacke {{ version }} *netlib                   # [blas_impl == 'blis']
+        - liblapack  ={{ version }}=*netlib                  # [blas_impl == 'blis']
+        - liblapacke ={{ version }}=*netlib                  # [blas_impl == 'blis']
         - {{ pin_subpackage("libcblas", exact=True) }}
         - {{ pin_subpackage("libblas", exact=True) }}
         - {{ pin_subpackage("blas-devel", exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,8 +7,6 @@
 # make sure we do not create colliding version strings of output "blas"
 # for builds across lapack-versions within the same blas_major
 {% set blas_minor = build_num + 100 %}
-{% set build_string_platform = target_platform | default("linux-64") %}
-{% set build_string_platform = build_string_platform.replace("-", "") %}
 
 package:
   name: blas-split
@@ -64,7 +62,7 @@ outputs:
     script: build_pkg.sh     # [unix]
     script: build_pkg.bat    # [win]
     build:
-      string: "{{ build_num }}_{{ build_string_platform }}_{{ blas_impl }}"
+      string: {{ build_num }}_h{{ PKG_HASH }}_{{ blas_impl }}
       run_exports:
         - {{ pin_subpackage("libblas", max_pin="x") }}
       track_features:
@@ -112,7 +110,7 @@ outputs:
     script: build_pkg.sh     # [unix]
     script: build_pkg.bat    # [win]
     build:
-      string: "{{ build_num }}_{{ build_string_platform }}_{{ blas_impl }}"
+      string: {{ build_num }}_h{{ PKG_HASH }}_{{ blas_impl }}
       run_exports:
         - {{ pin_subpackage("libcblas", max_pin="x") }}
       track_features:
@@ -144,7 +142,7 @@ outputs:
     script: build_pkg.sh     # [unix]
     script: build_pkg.bat    # [win]
     build:
-      string: "{{ build_num }}_{{ build_string_platform }}_{{ blas_impl }}"
+      string: {{ build_num }}_h{{ PKG_HASH }}_{{ blas_impl }}
       run_exports:
         - {{ pin_subpackage("liblapack", max_pin="x.x") }}
       track_features:
@@ -175,7 +173,7 @@ outputs:
     script: build_pkg.sh     # [unix]
     script: build_pkg.bat    # [win]
     build:
-      string: "{{ build_num }}_{{ build_string_platform }}_{{ blas_impl }}"
+      string: {{ build_num }}_h{{ PKG_HASH }}_{{ blas_impl }}
       run_exports:
         - {{ pin_subpackage("liblapacke", max_pin="x.x") }}
       track_features:
@@ -209,7 +207,7 @@ outputs:
     # uses lapack {{ version }}, not {{ blas_major }}
     script: install_blas_devel.sh   # [unix]
     build:
-      string: "{{ build_num }}_{{ build_string_platform }}_{{ blas_impl }}"
+      string: {{ build_num }}_h{{ PKG_HASH }}_{{ blas_impl }}
     requirements:
       host:
         - openblas   0.3.28  # [blas_impl == "openblas"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "3.9.0" %}
 # if build_num is reset to 0 (for new version), update increment for blas_minor below
-{% set build_num = 26 %}
+{% set build_num = 27 %}
 {% set version_major = version.split(".")[0] %}
 # blas_major denotes major infrastructural change to how blas is managed
 {% set blas_major = "2" %}
@@ -236,7 +236,7 @@ outputs:
     script: test_blas.sh   # [unix]
     script: test_blas.bat  # [win]
     build:
-      string: "{{ blas_impl }}"
+      string: {{ blas_impl }}
       activate_in_script: True
     requirements:
       build:
@@ -248,14 +248,19 @@ outputs:
         - llvm-openmp   # [linux and ((blas_impl == "openblas") or (blas_impl == "mkl"))]
       host:
       # Building with blis fails due to a conda-build bug
-      {% if blas_impl != 'blis' %}
+      {% if win and blas_impl == "openblas" %}
+        # cannot pin exactly due to pthreads/openmp distinction
+        - libblas ={{ version }}={{ build_num }}*_openblas
+        - libcblas ={{ version }}={{ build_num }}*_openblas
+        - liblapack ={{ version }}={{ build_num }}*_openblas
+        - liblapacke ={{ version }}={{ build_num }}*_openblas
+      {% elif blas_impl == "blis" %}
+        - blis 0.9.0
+      {% else %}
         - {{ pin_subpackage("liblapack", exact=True) }}
         - {{ pin_subpackage("liblapacke", exact=True) }}
         - {{ pin_subpackage("libcblas", exact=True) }}
         - {{ pin_subpackage("libblas", exact=True) }}
-        - openblas *={{ openblas_type }}*   # [win and blas_impl == 'openblas']
-      {% else %}
-        - blis 0.9.0
       {% endif %}
       run:
         - {{ pin_subpackage("liblapack", exact=True) }}      # [blas_impl != 'blis']

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,9 +83,10 @@ outputs:
         - {{ pin_compatible("mkl", max_pin="x", exact=win) }}              # [blas_impl == 'mkl']
         - {{ pin_compatible("blis", max_pin="x.x.x", exact=win) }}         # [blas_impl == 'blis']
       run_constrained:
-        - {{ pin_subpackage("libcblas", exact=True) }}
-        - {{ pin_subpackage("liblapack", exact=True) }}    # [blas_impl != 'blis']
-        - {{ pin_subpackage("liblapacke", exact=True) }}   # [blas_impl != 'blis']
+        # cannot pin exactly due to conda-build bug with nonsense hash in run_constrained
+        - libcblas ={{ version }}={{ build_num }}*_{{ blas_impl }}
+        - liblapack ={{ version }}={{ build_num }}*_{{ blas_impl }}     # [blas_impl != 'blis']
+        - liblapacke ={{ version }}={{ build_num }}*_{{ blas_impl }}    # [blas_impl != 'blis']
         - blas * {{ blas_impl }}
     files:
       - lib/libblas.so                          # [linux]
@@ -122,8 +123,9 @@ outputs:
       run:
         - {{ pin_subpackage("libblas", exact=True) }}
       run_constrained:
-        - {{ pin_subpackage("liblapack", exact=True) }}    # [blas_impl != 'blis']
-        - {{ pin_subpackage("liblapacke", exact=True) }}   # [blas_impl != 'blis']
+        # cannot pin exactly due to conda-build bug with nonsense hash in run_constrained
+        - liblapack ={{ version }}={{ build_num }}*_{{ blas_impl }}     # [blas_impl != 'blis']
+        - liblapacke ={{ version }}={{ build_num }}*_{{ blas_impl }}    # [blas_impl != 'blis']
         - blas * {{ blas_impl }}
     files:
       - lib/libcblas.so                          # [linux]
@@ -154,8 +156,9 @@ outputs:
       run:
         - {{ pin_subpackage("libblas", exact=True) }}
       run_constrained:
-        - {{ pin_subpackage("libcblas", exact=True) }}
-        - {{ pin_subpackage("liblapacke", exact=True) }}
+        # cannot pin exactly due to conda-build bug with nonsense hash in run_constrained
+        - libcblas ={{ version }}={{ build_num }}*_{{ blas_impl }}
+        - liblapacke ={{ version }}={{ build_num }}*_{{ blas_impl }}
         - blas * {{ blas_impl }}
     files:
       - lib/liblapack.so                          # [linux]


### PR DESCRIPTION
Follow-up to #126. Due to the exact pin on windows
https://github.com/conda-forge/blas-feedstock/blob/23be843579f426d372c23506e03c1c35546e7502/recipe/meta.yaml#L84
we need to loosen the pin in `blas`; otherwise the fully qualified build (name + version + string) collides and only the first one gets uploaded, which is incompatible with `pin_subpackage(..., exact=True)`.

By keeping the ends of the build strings untouched (both sides in the case of `blas`), this cannot break any existing usage patterns. Nevertheless I also checked [usage](https://github.com/search?q=org%3Aconda-forge+%2F%5Cb%28lib%29%3Fblas%5Cs*%5B%5Cd%5C*%3D%5D%2B%2F+path%3Arecipe%2Fmeta.yaml&type=code) in conda-forge; couldn't find any example that would be invalidated.