### PR TITLE
Distinguish openblas variants on windows; remove blis workarounds

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,23 +11,23 @@ jobs:
       linux_64_blas_implblisblas_impl_liblibblis.so.4:
         CONFIG: linux_64_blas_implblisblas_impl_liblibblis.so.4
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_64_blas_implmklblas_impl_liblibmkl_rt.so:
         CONFIG: linux_64_blas_implmklblas_impl_liblibmkl_rt.so
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_64_blas_implopenblasblas_impl_liblibopenblas.so.0:
         CONFIG: linux_64_blas_implopenblasblas_impl_liblibopenblas.so.0
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_:
         CONFIG: linux_aarch64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_ppc64le_:
         CONFIG: linux_ppc64le_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -33,6 +33,7 @@ jobs:
       displayName: Run Windows build
       env:
         MINIFORGE_HOME: $(MINIFORGE_HOME)
+        CONDA_BLD_PATH: $(CONDA_BLD_PATH)
         PYTHONUNBUFFERED: 1
         CONFIG: $(CONFIG)
         CI: azure

--- a/.ci_support/linux_64_blas_implblisblas_impl_liblibblis.so.4.yaml
+++ b/.ci_support/linux_64_blas_implblisblas_impl_liblibblis.so.4.yaml
@@ -25,17 +25,15 @@ fortran_compiler:
 fortran_compiler_version:
 - '13'
 libblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 libcblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapack:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapacke:
-- 3.9 *netlib
+- 3.9.* *netlib
 mkl:
-- '2023'
-openblas:
-- 0.3.*
+- '2024'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_blas_implblisblas_impl_liblibblis.so.4.yaml
+++ b/.ci_support/linux_64_blas_implblisblas_impl_liblibblis.so.4.yaml
@@ -1,5 +1,3 @@
-ace:
-- 8.0.1
 blas_default_impl:
 - openblas
 blas_impl:
@@ -21,11 +19,23 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
+mkl:
+- '2023'
+openblas:
+- 0.3.*
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_blas_implmklblas_impl_liblibmkl_rt.so.yaml
+++ b/.ci_support/linux_64_blas_implmklblas_impl_liblibmkl_rt.so.yaml
@@ -25,17 +25,15 @@ fortran_compiler:
 fortran_compiler_version:
 - '13'
 libblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 libcblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapack:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapacke:
-- 3.9 *netlib
+- 3.9.* *netlib
 mkl:
-- '2023'
-openblas:
-- 0.3.*
+- '2024'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_blas_implmklblas_impl_liblibmkl_rt.so.yaml
+++ b/.ci_support/linux_64_blas_implmklblas_impl_liblibmkl_rt.so.yaml
@@ -1,5 +1,3 @@
-ace:
-- 8.0.1
 blas_default_impl:
 - openblas
 blas_impl:
@@ -21,11 +19,23 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
+mkl:
+- '2023'
+openblas:
+- 0.3.*
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_blas_implopenblasblas_impl_liblibopenblas.so.0.yaml
+++ b/.ci_support/linux_64_blas_implopenblasblas_impl_liblibopenblas.so.0.yaml
@@ -25,17 +25,15 @@ fortran_compiler:
 fortran_compiler_version:
 - '13'
 libblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 libcblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapack:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapacke:
-- 3.9 *netlib
+- 3.9.* *netlib
 mkl:
-- '2023'
-openblas:
-- 0.3.*
+- '2024'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_blas_implopenblasblas_impl_liblibopenblas.so.0.yaml
+++ b/.ci_support/linux_64_blas_implopenblasblas_impl_liblibopenblas.so.0.yaml
@@ -1,5 +1,3 @@
-ace:
-- 8.0.1
 blas_default_impl:
 - openblas
 blas_impl:
@@ -21,11 +19,23 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
+mkl:
+- '2023'
+openblas:
+- 0.3.*
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -25,15 +25,13 @@ fortran_compiler:
 fortran_compiler_version:
 - '13'
 libblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 libcblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapack:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapacke:
-- 3.9 *netlib
-openblas:
-- 0.3.*
+- 3.9.* *netlib
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,7 +1,3 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
-ace:
-- 8.0.1
 blas_default_impl:
 - openblas
 blas_impl:
@@ -16,8 +12,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_arch:
-- aarch64
 cdt_name:
 - conda
 channel_sources:
@@ -25,11 +19,21 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
+openblas:
+- 0.3.*
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -25,15 +25,13 @@ fortran_compiler:
 fortran_compiler_version:
 - '13'
 libblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 libcblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapack:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapacke:
-- 3.9 *netlib
-openblas:
-- 0.3.*
+- 3.9.* *netlib
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,5 +1,3 @@
-ace:
-- 8.0.1
 blas_default_impl:
 - openblas
 blas_impl:
@@ -21,11 +19,21 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
+openblas:
+- 0.3.*
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/osx_64_blas_implaccelerateblas_impl_liblibvecLibFort-ng.dylib.yaml
+++ b/.ci_support/osx_64_blas_implaccelerateblas_impl_liblibvecLibFort-ng.dylib.yaml
@@ -25,17 +25,17 @@ fortran_compiler:
 fortran_compiler_version:
 - '13'
 libblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 libcblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapack:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapacke:
-- 3.9 *netlib
+- 3.9.* *netlib
+llvm_openmp:
+- '18'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-openblas:
-- 0.3.*
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blas_implaccelerateblas_impl_liblibvecLibFort-ng.dylib.yaml
+++ b/.ci_support/osx_64_blas_implaccelerateblas_impl_liblibvecLibFort-ng.dylib.yaml
@@ -2,8 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.13'
 MACOSX_SDK_VERSION:
 - '10.13'
-ace:
-- 8.0.1
 blas_default_impl:
 - openblas
 blas_impl:
@@ -26,8 +24,18 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
+openblas:
+- 0.3.*
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blas_implblisblas_impl_liblibblis.4.dylib.yaml
+++ b/.ci_support/osx_64_blas_implblisblas_impl_liblibblis.4.dylib.yaml
@@ -25,17 +25,17 @@ fortran_compiler:
 fortran_compiler_version:
 - '13'
 libblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 libcblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapack:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapacke:
-- 3.9 *netlib
+- 3.9.* *netlib
+llvm_openmp:
+- '18'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-openblas:
-- 0.3.*
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blas_implblisblas_impl_liblibblis.4.dylib.yaml
+++ b/.ci_support/osx_64_blas_implblisblas_impl_liblibblis.4.dylib.yaml
@@ -2,8 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.13'
 MACOSX_SDK_VERSION:
 - '10.13'
-ace:
-- 8.0.1
 blas_default_impl:
 - openblas
 blas_impl:
@@ -26,8 +24,18 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
+openblas:
+- 0.3.*
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blas_implopenblasblas_impl_liblibopenblas.0.dylib.yaml
+++ b/.ci_support/osx_64_blas_implopenblasblas_impl_liblibopenblas.0.dylib.yaml
@@ -25,17 +25,17 @@ fortran_compiler:
 fortran_compiler_version:
 - '13'
 libblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 libcblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapack:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapacke:
-- 3.9 *netlib
+- 3.9.* *netlib
+llvm_openmp:
+- '18'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-openblas:
-- 0.3.*
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blas_implopenblasblas_impl_liblibopenblas.0.dylib.yaml
+++ b/.ci_support/osx_64_blas_implopenblasblas_impl_liblibopenblas.0.dylib.yaml
@@ -2,8 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.13'
 MACOSX_SDK_VERSION:
 - '10.13'
-ace:
-- 8.0.1
 blas_default_impl:
 - openblas
 blas_impl:
@@ -26,8 +24,18 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
+openblas:
+- 0.3.*
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_arm64_blas_implaccelerateblas_impl_liblibvecLibFort-ng.dylib.yaml
+++ b/.ci_support/osx_arm64_blas_implaccelerateblas_impl_liblibvecLibFort-ng.dylib.yaml
@@ -2,8 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
-ace:
-- 8.0.1
 blas_default_impl:
 - openblas
 blas_impl:
@@ -26,8 +24,18 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
 macos_machine:
 - arm64-apple-darwin20.0.0
+openblas:
+- 0.3.*
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_blas_implaccelerateblas_impl_liblibvecLibFort-ng.dylib.yaml
+++ b/.ci_support/osx_arm64_blas_implaccelerateblas_impl_liblibvecLibFort-ng.dylib.yaml
@@ -25,17 +25,17 @@ fortran_compiler:
 fortran_compiler_version:
 - '13'
 libblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 libcblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapack:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapacke:
-- 3.9 *netlib
+- 3.9.* *netlib
+llvm_openmp:
+- '18'
 macos_machine:
 - arm64-apple-darwin20.0.0
-openblas:
-- 0.3.*
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_blas_implopenblasblas_impl_liblibopenblas.0.dylib.yaml
+++ b/.ci_support/osx_arm64_blas_implopenblasblas_impl_liblibopenblas.0.dylib.yaml
@@ -2,8 +2,6 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
-ace:
-- 8.0.1
 blas_default_impl:
 - openblas
 blas_impl:
@@ -26,8 +24,18 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
 macos_machine:
 - arm64-apple-darwin20.0.0
+openblas:
+- 0.3.*
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_blas_implopenblasblas_impl_liblibopenblas.0.dylib.yaml
+++ b/.ci_support/osx_arm64_blas_implopenblasblas_impl_liblibopenblas.0.dylib.yaml
@@ -25,17 +25,17 @@ fortran_compiler:
 fortran_compiler_version:
 - '13'
 libblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 libcblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapack:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapacke:
-- 3.9 *netlib
+- 3.9.* *netlib
+llvm_openmp:
+- '18'
 macos_machine:
 - arm64-apple-darwin20.0.0
-openblas:
-- 0.3.*
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/win_64_blas_implblisblas_impl_liblibblis.4.dllopenblas_typedummy.yaml
+++ b/.ci_support/win_64_blas_implblisblas_impl_liblibblis.4.dllopenblas_typedummy.yaml
@@ -17,17 +17,15 @@ fortran_compiler:
 fortran_compiler_version:
 - '19'
 libblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 libcblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapack:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapacke:
-- 3.9 *netlib
+- 3.9.* *netlib
 mkl:
-- '2023'
-openblas:
-- 0.3.*
+- '2024'
 openblas_type:
 - dummy
 target_platform:

--- a/.ci_support/win_64_blas_implblisblas_impl_liblibblis.4.dllopenblas_typedummy.yaml
+++ b/.ci_support/win_64_blas_implblisblas_impl_liblibblis.4.dllopenblas_typedummy.yaml
@@ -1,5 +1,3 @@
-ace:
-- 8.0.1
 blas_default_impl:
 - mkl
 blas_impl:
@@ -18,6 +16,16 @@ fortran_compiler:
 - flang
 fortran_compiler_version:
 - '19'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
+mkl:
+- '2023'
 openblas:
 - 0.3.*
 openblas_type:

--- a/.ci_support/win_64_blas_implmklblas_impl_libmkl_rt.2.dllopenblas_typedummy.yaml
+++ b/.ci_support/win_64_blas_implmklblas_impl_libmkl_rt.2.dllopenblas_typedummy.yaml
@@ -17,17 +17,15 @@ fortran_compiler:
 fortran_compiler_version:
 - '19'
 libblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 libcblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapack:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapacke:
-- 3.9 *netlib
+- 3.9.* *netlib
 mkl:
-- '2023'
-openblas:
-- 0.3.*
+- '2024'
 openblas_type:
 - dummy
 target_platform:

--- a/.ci_support/win_64_blas_implmklblas_impl_libmkl_rt.2.dllopenblas_typedummy.yaml
+++ b/.ci_support/win_64_blas_implmklblas_impl_libmkl_rt.2.dllopenblas_typedummy.yaml
@@ -1,5 +1,3 @@
-ace:
-- 8.0.1
 blas_default_impl:
 - mkl
 blas_impl:
@@ -18,6 +16,16 @@ fortran_compiler:
 - flang
 fortran_compiler_version:
 - '19'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
+mkl:
+- '2023'
 openblas:
 - 0.3.*
 openblas_type:

--- a/.ci_support/win_64_blas_implopenblasblas_impl_libopenblas.dllopenblas_typeopenmp.yaml
+++ b/.ci_support/win_64_blas_implopenblasblas_impl_libopenblas.dllopenblas_typeopenmp.yaml
@@ -1,5 +1,3 @@
-ace:
-- 8.0.1
 blas_default_impl:
 - mkl
 blas_impl:
@@ -18,6 +16,16 @@ fortran_compiler:
 - flang
 fortran_compiler_version:
 - '19'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
+mkl:
+- '2023'
 openblas:
 - 0.3.*
 openblas_type:

--- a/.ci_support/win_64_blas_implopenblasblas_impl_libopenblas.dllopenblas_typeopenmp.yaml
+++ b/.ci_support/win_64_blas_implopenblasblas_impl_libopenblas.dllopenblas_typeopenmp.yaml
@@ -17,17 +17,15 @@ fortran_compiler:
 fortran_compiler_version:
 - '19'
 libblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 libcblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapack:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapacke:
-- 3.9 *netlib
+- 3.9.* *netlib
 mkl:
-- '2023'
-openblas:
-- 0.3.*
+- '2024'
 openblas_type:
 - openmp
 target_platform:

--- a/.ci_support/win_64_blas_implopenblasblas_impl_libopenblas.dllopenblas_typepthreads.yaml
+++ b/.ci_support/win_64_blas_implopenblasblas_impl_libopenblas.dllopenblas_typepthreads.yaml
@@ -1,5 +1,3 @@
-ace:
-- 8.0.1
 blas_default_impl:
 - mkl
 blas_impl:
@@ -18,6 +16,16 @@ fortran_compiler:
 - flang
 fortran_compiler_version:
 - '19'
+libblas:
+- 3.9 *netlib
+libcblas:
+- 3.9 *netlib
+liblapack:
+- 3.9 *netlib
+liblapacke:
+- 3.9 *netlib
+mkl:
+- '2023'
 openblas:
 - 0.3.*
 openblas_type:

--- a/.ci_support/win_64_blas_implopenblasblas_impl_libopenblas.dllopenblas_typepthreads.yaml
+++ b/.ci_support/win_64_blas_implopenblasblas_impl_libopenblas.dllopenblas_typepthreads.yaml
@@ -17,17 +17,15 @@ fortran_compiler:
 fortran_compiler_version:
 - '19'
 libblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 libcblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapack:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapacke:
-- 3.9 *netlib
+- 3.9.* *netlib
 mkl:
-- '2023'
-openblas:
-- 0.3.*
+- '2024'
 openblas_type:
 - pthreads
 target_platform:

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -35,7 +35,7 @@ mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-
 echo > /opt/conda/conda-meta/history
 micromamba install --root-prefix ~/.conda --prefix /opt/conda \
     --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.11"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -35,7 +35,7 @@ mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-
 echo > /opt/conda/conda-meta/history
 micromamba install --root-prefix ~/.conda --prefix /opt/conda \
     --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.11"
+    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -6,8 +6,9 @@ source .scripts/logging_utils.sh
 
 set -xe
 
-MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
-MINIFORGE_HOME=${MINIFORGE_HOME%/} # remove trailing slash
+MINIFORGE_HOME="${MINIFORGE_HOME:-${HOME}/miniforge3}"
+MINIFORGE_HOME="${MINIFORGE_HOME%/}" # remove trailing slash
+export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${MINIFORGE_HOME}/conda-bld}"
 
 ( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
 MICROMAMBA_VERSION="1.5.10-0"
@@ -25,7 +26,7 @@ chmod +x "${micromamba_exe}"
 echo "Creating environment"
 "${micromamba_exe}" create --yes --root-prefix "${MAMBA_ROOT_PREFIX}" --prefix "${MINIFORGE_HOME}" \
   --channel conda-forge \
-  pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+  pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.11"
 echo "Moving pkgs cache from ${MAMBA_ROOT_PREFIX} to ${MINIFORGE_HOME}"
 mv "${MAMBA_ROOT_PREFIX}/pkgs" "${MINIFORGE_HOME}"
 echo "Cleaning up micromamba"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -26,7 +26,7 @@ chmod +x "${micromamba_exe}"
 echo "Creating environment"
 "${micromamba_exe}" create --yes --root-prefix "${MAMBA_ROOT_PREFIX}" --prefix "${MINIFORGE_HOME}" \
   --channel conda-forge \
-  pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.11"
+  pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 echo "Moving pkgs cache from ${MAMBA_ROOT_PREFIX} to ${MINIFORGE_HOME}"
 mv "${MAMBA_ROOT_PREFIX}/pkgs" "${MINIFORGE_HOME}"
 echo "Cleaning up micromamba"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -31,11 +31,12 @@ if !errorlevel! neq 0 exit /b !errorlevel!
 echo Creating environment
 call "%MICROMAMBA_EXE%" create --yes --root-prefix "%MAMBA_ROOT_PREFIX%" --prefix "%MINIFORGE_HOME%" ^
     --channel conda-forge ^
-    pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+    pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.11"
 if !errorlevel! neq 0 exit /b !errorlevel!
 echo Removing %MAMBA_ROOT_PREFIX%
 del /S /Q "%MAMBA_ROOT_PREFIX%" >nul
 del /S /Q "%MICROMAMBA_TMPDIR%" >nul
+call :end_group
 
 call :start_group "Configuring conda"
 

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -31,7 +31,7 @@ if !errorlevel! neq 0 exit /b !errorlevel!
 echo Creating environment
 call "%MICROMAMBA_EXE%" create --yes --root-prefix "%MAMBA_ROOT_PREFIX%" --prefix "%MINIFORGE_HOME%" ^
     --channel conda-forge ^
-    pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.11"
+    pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 if !errorlevel! neq 0 exit /b !errorlevel!
 echo Removing %MAMBA_ROOT_PREFIX%
 del /S /Q "%MAMBA_ROOT_PREFIX%" >nul

--- a/build-locally.py
+++ b/build-locally.py
@@ -26,6 +26,13 @@ def setup_environment(ns):
             os.path.dirname(__file__), "miniforge3"
         )
 
+    # The default cache location might not be writable using docker on macOS.
+    if ns.config.startswith("linux") and platform.system() == "Darwin":
+        os.environ["CONDA_FORGE_DOCKER_RUN_ARGS"] = (
+            os.environ.get("CONDA_FORGE_DOCKER_RUN_ARGS", "")
+            + " -e RATTLER_CACHE_DIR=/tmp/rattler_cache"
+        )
+
 
 def run_docker_build(ns):
     script = ".scripts/run_docker_build.sh"

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -11,4 +11,7 @@ github:
 provider:
   linux_aarch64: default
   linux_ppc64le: default
+remote_ci_setup:
+  - conda-forge-ci-setup=4
+  - conda-build>=24.11
 test: native_and_emulated

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -11,7 +11,4 @@ github:
 provider:
   linux_aarch64: default
   linux_ppc64le: default
-remote_ci_setup:
-  - conda-forge-ci-setup=4
-  - conda-build>=24.11
 test: native_and_emulated

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "3.9.0" %}
 # if build_num is reset to 0 (for new version), update increment for blas_minor below
-{% set build_num = 26 %}
+{% set build_num = 27 %}
 {% set version_major = version.split(".")[0] %}
 # blas_major denotes major infrastructural change to how blas is managed
 {% set blas_major = "2" %}
@@ -238,7 +238,7 @@ outputs:
     script: test_blas.sh   # [unix]
     script: test_blas.bat  # [win]
     build:
-      string: "{{ blas_impl }}"
+      string: {{ blas_impl }}
       activate_in_script: True
     requirements:
       build:
@@ -249,13 +249,21 @@ outputs:
         - ninja         # [win]
         - llvm-openmp   # [linux and ((blas_impl == "openblas") or (blas_impl == "mkl"))]
       host:
+      {% if win and blas_impl == "openblas" %}
+        # cannot pin exactly due to pthreads/openmp distinction
+        - libblas ={{ version }}={{ build_num }}*_openblas
+        - libcblas ={{ version }}={{ build_num }}*_openblas
+        - liblapack ={{ version }}={{ build_num }}*_openblas
+        - liblapacke ={{ version }}={{ build_num }}*_openblas
         - openblas *={{ openblas_type }}*   # [win and blas_impl == 'openblas']
+      {% else %}
         - {{ pin_subpackage("libblas", exact=True) }}
         - {{ pin_subpackage("libcblas", exact=True) }}
         - {{ pin_subpackage("liblapack", exact=True) }}      # [blas_impl != 'blis']
         - {{ pin_subpackage("liblapacke", exact=True) }}     # [blas_impl != 'blis']
         - liblapack  {{ version }} *netlib                   # [blas_impl == 'blis']
         - liblapacke {{ version }} *netlib                   # [blas_impl == 'blis']
+      {% endif %}
       run:
         - {{ pin_subpackage("libblas", exact=True) }}
         - {{ pin_subpackage("libcblas", exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,8 +7,6 @@
 # make sure we do not create colliding version strings of output "blas"
 # for builds across lapack-versions within the same blas_major
 {% set blas_minor = build_num + 100 %}
-{% set build_string_platform = target_platform | default("linux-64") %}
-{% set build_string_platform = build_string_platform.replace("-", "") %}
 
 package:
   name: blas-split
@@ -64,7 +62,7 @@ outputs:
     script: build_pkg.sh     # [unix]
     script: build_pkg.bat    # [win]
     build:
-      string: "{{ build_num }}_{{ build_string_platform }}_{{ blas_impl }}"
+      string: {{ build_num }}_h{{ PKG_HASH }}_{{ blas_impl }}
       run_exports:
         - {{ pin_subpackage("libblas", max_pin="x") }}
       track_features:
@@ -112,7 +110,7 @@ outputs:
     script: build_pkg.sh     # [unix]
     script: build_pkg.bat    # [win]
     build:
-      string: "{{ build_num }}_{{ build_string_platform }}_{{ blas_impl }}"
+      string: {{ build_num }}_h{{ PKG_HASH }}_{{ blas_impl }}
       run_exports:
         - {{ pin_subpackage("libcblas", max_pin="x") }}
       track_features:
@@ -144,7 +142,7 @@ outputs:
     script: build_pkg.sh     # [unix]
     script: build_pkg.bat    # [win]
     build:
-      string: "{{ build_num }}_{{ build_string_platform }}_{{ blas_impl }}"
+      string: {{ build_num }}_h{{ PKG_HASH }}_{{ blas_impl }}
       run_exports:
         - {{ pin_subpackage("liblapack", max_pin="x.x") }}
       track_features:
@@ -175,7 +173,7 @@ outputs:
     script: build_pkg.sh     # [unix]
     script: build_pkg.bat    # [win]
     build:
-      string: "{{ build_num }}_{{ build_string_platform }}_{{ blas_impl }}"
+      string: {{ build_num }}_h{{ PKG_HASH }}_{{ blas_impl }}
       run_exports:
         - {{ pin_subpackage("liblapacke", max_pin="x.x") }}
       track_features:
@@ -209,7 +207,7 @@ outputs:
     # uses lapack {{ version }}, not {{ blas_major }}
     script: install_blas_devel.sh   # [unix]
     build:
-      string: "{{ build_num }}_{{ build_string_platform }}_{{ blas_impl }}"
+      string: {{ build_num }}_h{{ PKG_HASH }}_{{ blas_impl }}
     requirements:
       host:
         - openblas   0.3.28  # [blas_impl == "openblas"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -273,10 +273,9 @@ outputs:
         - ninja         # [win]
         - llvm-openmp   # [linux and ((blas_impl == "openblas") or (blas_impl == "mkl"))]
       host:
-        - {{ pin_subpackage("blas-devel", exact=True) }}
-        - openblas =*={{ openblas_type }}*  # [win and blas_impl == 'openblas']
+        - blas-devel {{ version }} {{ build_num }}*_{{ blas_impl }}
       run:
-        - {{ pin_subpackage("blas-devel", exact=True) }}
+        - blas-devel {{ version }} {{ build_num }}*_{{ blas_impl }}
     test:
       commands:
         - test -f $PREFIX/lib/liblapacke.so                          # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -82,7 +82,8 @@ outputs:
         - mkl  {{ mkl_version }}                # [blas_impl == 'mkl']
         - libopenblas {{ openblas_version }}    # [blas_impl == 'openblas']
         # on windows we pin exactly, so need to build twice
-        - libopenblas =*={{ openblas_type }}*   # [blas_impl == 'openblas' and win]
+        - libopenblas =*={{ openblas_type }}*   # [win and blas_impl == 'openblas']
+        - llvm-openmp                           # [win and openblas_type == 'openmp']
       run:
         - {{ pin_compatible("libopenblas", max_pin="x.x.x", exact=win) }}  # [blas_impl == 'openblas']
         - {{ pin_compatible("mkl", max_pin="x", exact=win) }}              # [blas_impl == 'mkl']
@@ -126,6 +127,7 @@ outputs:
         # cannot pin exactly due to https://github.com/conda/conda-build/issues/5573
         - libblas ={{ version }}={{ build_num }}*_{{ blas_impl }}
         - libopenblas =*={{ openblas_type }}*   # [win and blas_impl == 'openblas']
+        - llvm-openmp                           # [win and openblas_type == 'openmp']
       run:
         - libblas ={{ version }}={{ build_num }}*_{{ blas_impl }}
       run_constrained:
@@ -159,6 +161,7 @@ outputs:
       host:
         - {{ pin_subpackage("libblas", exact=True) }}
         - libopenblas =*={{ openblas_type }}*   # [win and blas_impl == 'openblas']
+        - llvm-openmp                           # [win and openblas_type == 'openmp']
       run:
         - {{ pin_subpackage("libblas", exact=True) }}
       run_constrained:
@@ -194,6 +197,7 @@ outputs:
         - {{ pin_subpackage("libcblas", exact=True) }}
         - {{ pin_subpackage("liblapack", exact=True) }}
         - libopenblas =*={{ openblas_type }}*   # [win and blas_impl == 'openblas']
+        - llvm-openmp                           # [win and openblas_type == 'openmp']
       run:
         - {{ pin_subpackage("libblas", exact=True) }}
         - {{ pin_subpackage("libcblas", exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -253,6 +253,12 @@ outputs:
     build:
       string: {{ blas_impl }}
       activate_in_script: True
+      ignore_run_exports_from:
+        # this is a metapackage; ignore the run-exports from the build environment
+        - {{ stdlib("c") }}
+        - {{ compiler("c") }}
+        - {{ compiler("fortran") }}
+        - llvm-openmp
     requirements:
       build:
         - {{ stdlib("c") }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -221,12 +221,12 @@ outputs:
         - openblas   0.3.28  # [blas_impl == "openblas"]
         - mkl-devel  2024.2  # [blas_impl == "mkl"]
         - blis 0.9.0         # [blas_impl == "blis"]
+        - {{ pin_subpackage("libblas", exact=True) }}
+        - {{ pin_subpackage("libcblas", exact=True) }}
         - {{ pin_subpackage("liblapack", exact=True) }}      # [blas_impl != 'blis']
         - {{ pin_subpackage("liblapacke", exact=True) }}     # [blas_impl != 'blis']
         - liblapack  {{ version }} *netlib                   # [blas_impl == 'blis']
         - liblapacke {{ version }} *netlib                   # [blas_impl == 'blis']
-        - {{ pin_subpackage("libcblas", exact=True) }}
-        - {{ pin_subpackage("libblas", exact=True) }}
     test:
       commands:
         - test -f $PREFIX/lib/pkgconfig/blas.pc                     # [unix and blas_impl == "openblas"]
@@ -260,18 +260,24 @@ outputs:
         - liblapacke ={{ version }}={{ build_num }}*_openblas
         - openblas *={{ openblas_type }}*   # [win and blas_impl == 'openblas']
       {% else %}
-        - {{ pin_subpackage("libblas", exact=True) }}
-        - {{ pin_subpackage("libcblas", exact=True) }}
+        - {{ pin_subpackage("libblas", exact=True) }}        # [blas_impl != 'blis']
+        - {{ pin_subpackage("libcblas", exact=True) }}       # [blas_impl != 'blis']
         - {{ pin_subpackage("liblapack", exact=True) }}      # [blas_impl != 'blis']
         - {{ pin_subpackage("liblapacke", exact=True) }}     # [blas_impl != 'blis']
+        # don't libblas/libcblas exactly due to issues with exact=True,
+        # see https://github.com/conda/conda-build/issues/5573
+        - libblas    {{ version }} *netlib                   # [blas_impl == 'blis']
+        - libcblas   {{ version }} *netlib                   # [blas_impl == 'blis']
         - liblapack  {{ version }} *netlib                   # [blas_impl == 'blis']
         - liblapacke {{ version }} *netlib                   # [blas_impl == 'blis']
       {% endif %}
       run:
-        - {{ pin_subpackage("libblas", exact=True) }}
-        - {{ pin_subpackage("libcblas", exact=True) }}
+        - {{ pin_subpackage("libblas", exact=True) }}        # [blas_impl != 'blis']
+        - {{ pin_subpackage("libcblas", exact=True) }}       # [blas_impl != 'blis']
         - {{ pin_subpackage("liblapack", exact=True) }}      # [blas_impl != 'blis']
         - {{ pin_subpackage("liblapacke", exact=True) }}     # [blas_impl != 'blis']
+        - libblas    {{ version }} *netlib                   # [blas_impl == 'blis']
+        - libcblas   {{ version }} *netlib                   # [blas_impl == 'blis']
         - liblapack  {{ version }} *netlib                   # [blas_impl == 'blis']
         - liblapacke {{ version }} *netlib                   # [blas_impl == 'blis']
         - {{ pin_subpackage("blas-devel", exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -221,10 +221,14 @@ outputs:
         - openblas   0.3.28  # [blas_impl == "openblas"]
         - mkl-devel  2024.2  # [blas_impl == "mkl"]
         - blis 0.9.0         # [blas_impl == "blis"]
-        - {{ pin_subpackage("libblas", exact=True) }}
-        - {{ pin_subpackage("libcblas", exact=True) }}
+        - {{ pin_subpackage("libblas", exact=True) }}        # [blas_impl != 'blis']
+        - {{ pin_subpackage("libcblas", exact=True) }}       # [blas_impl != 'blis']
         - {{ pin_subpackage("liblapack", exact=True) }}      # [blas_impl != 'blis']
         - {{ pin_subpackage("liblapacke", exact=True) }}     # [blas_impl != 'blis']
+        # don't libblas/libcblas exactly due to issues with exact=True,
+        # see https://github.com/conda/conda-build/issues/5573
+        - libblas    {{ version }} *netlib                   # [blas_impl == 'blis']
+        - libcblas   {{ version }} *netlib                   # [blas_impl == 'blis']
         - liblapack  {{ version }} *netlib                   # [blas_impl == 'blis']
         - liblapacke {{ version }} *netlib                   # [blas_impl == 'blis']
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -238,8 +238,12 @@ outputs:
         - test -f $PREFIX/lib/pkgconfig/blas.pc                     # [unix and blas_impl == "openblas"]
         - test -f $PREFIX/lib/liblapack.so                          # [linux]
         - test -f $PREFIX/lib/liblapack.dylib                       # [osx]
+        - test -f $PREFIX/lib/liblapacke.so                         # [linux]
+        - test -f $PREFIX/lib/liblapacke.so.{{ version_major }}     # [linux]
+        - test -f $PREFIX/lib/liblapacke.dylib                      # [osx]
+        - test -f $PREFIX/lib/liblapacke.{{ version_major }}.dylib  # [osx]
         - if not exist %LIBRARY_BIN%/liblapack.dll exit 1           # [win]
-
+        - if not exist %LIBRARY_BIN%/liblapacke.dll exit 1          # [win]
 
   # For compatiblity
   - name: blas
@@ -258,44 +262,13 @@ outputs:
         - ninja         # [win]
         - llvm-openmp   # [linux and ((blas_impl == "openblas") or (blas_impl == "mkl"))]
       host:
-      {% if win and blas_impl == "openblas" %}
-        # cannot pin exactly due to pthreads/openmp distinction
-        - libblas ={{ version }}={{ build_num }}*_openblas
-        - libcblas ={{ version }}={{ build_num }}*_openblas
-        - liblapack ={{ version }}={{ build_num }}*_openblas
-        - liblapacke ={{ version }}={{ build_num }}*_openblas
+        - {{ pin_subpackage("blas-devel", exact=True) }}
         - openblas *={{ openblas_type }}*   # [win and blas_impl == 'openblas']
-      {% else %}
-        - {{ pin_subpackage("libblas", exact=True) }}        # [blas_impl != 'blis']
-        - {{ pin_subpackage("libcblas", exact=True) }}       # [blas_impl != 'blis']
-        - {{ pin_subpackage("liblapack", exact=True) }}      # [blas_impl != 'blis']
-        - {{ pin_subpackage("liblapacke", exact=True) }}     # [blas_impl != 'blis']
-        # don't pin libblas/libcblas exactly due to issues with exact=True,
-        # see https://github.com/conda/conda-build/issues/5573
-        - libblas    ={{ version }}={{ build_num }}*_blis    # [blas_impl == 'blis']
-        - libcblas   ={{ version }}={{ build_num }}*_blis    # [blas_impl == 'blis']
-        # netlib variants don't have the same build number
-        - liblapack  ={{ version }}=*_netlib                 # [blas_impl == 'blis']
-        - liblapacke ={{ version }}=*_netlib                 # [blas_impl == 'blis']
-      {% endif %}
       run:
-        - {{ pin_subpackage("blas-devel", exact=True) }}     # [blas_impl != 'blis']
-        - {{ pin_subpackage("libblas", exact=True) }}        # [blas_impl != 'blis']
-        - {{ pin_subpackage("libcblas", exact=True) }}       # [blas_impl != 'blis']
-        - {{ pin_subpackage("liblapack", exact=True) }}      # [blas_impl != 'blis']
-        - {{ pin_subpackage("liblapacke", exact=True) }}     # [blas_impl != 'blis']
-        - blas-devel ={{ version }}={{ build_num }}*_blis    # [blas_impl == 'blis']
-        - libblas    ={{ version }}={{ build_num }}*_blis    # [blas_impl == 'blis']
-        - libcblas   ={{ version }}={{ build_num }}*_blis    # [blas_impl == 'blis']
-        - liblapack  ={{ version }}=*_netlib                 # [blas_impl == 'blis']
-        - liblapacke ={{ version }}=*_netlib                 # [blas_impl == 'blis']
+        - {{ pin_subpackage("blas-devel", exact=True) }}
     test:
       commands:
-        - test -f $PREFIX/lib/liblapacke.so                          # [linux]
-        - test -f $PREFIX/lib/liblapacke.so.{{ version_major }}      # [linux]
-        - test -f $PREFIX/lib/liblapacke.dylib                       # [osx]
-        - test -f $PREFIX/lib/liblapacke.{{ version_major }}.dylib   # [osx]
-        - if not exist %LIBRARY_BIN%/liblapacke.dll exit 1           # [win]
+        - echo tested in build script
 
 about:
   home: https://github.com/conda-forge/blas-feedstock

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -231,14 +231,10 @@ outputs:
         - blis      {{ blis_version }}      # [blas_impl == "blis"]
         - mkl-devel {{ mkl_version }}       # [blas_impl == "mkl"]
         - openblas  {{ openblas_version }}  # [blas_impl == "openblas"]
-        - {{ pin_subpackage("libblas", exact=True) }}        # [blas_impl != 'blis']
-        - {{ pin_subpackage("libcblas", exact=True) }}       # [blas_impl != 'blis']
+        - {{ pin_subpackage("libblas", exact=True) }}
+        - {{ pin_subpackage("libcblas", exact=True) }}
         - {{ pin_subpackage("liblapack", exact=True) }}      # [blas_impl != 'blis']
         - {{ pin_subpackage("liblapacke", exact=True) }}     # [blas_impl != 'blis']
-        # don't pin libblas/libcblas exactly due to issues with exact=True,
-        # see https://github.com/conda/conda-build/issues/5573
-        - libblas    ={{ version }}={{ build_num }}*_blis    # [blas_impl == 'blis']
-        - libcblas   ={{ version }}={{ build_num }}*_blis    # [blas_impl == 'blis']
         # netlib variants don't have the same build number
         - liblapack  ={{ version }}=*_netlib                 # [blas_impl == 'blis']
         - liblapacke ={{ version }}=*_netlib                 # [blas_impl == 'blis']

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -140,11 +140,11 @@ outputs:
         - test -f $PREFIX/lib/libcblas.{{ version_major }}.dylib   # [osx]
         - if not exist %LIBRARY_BIN%/libcblas.dll exit 1           # [win]
 
-  {% if blas_impl != 'blis' %}
   - name: liblapack
     script: build_pkg.sh     # [unix]
     script: build_pkg.bat    # [win]
     build:
+      skip: true  # [blas_impl == 'blis']
       string: {{ build_num }}_h{{ PKG_HASH }}_{{ blas_impl }}
       run_exports:
         - {{ pin_subpackage("liblapack", max_pin="x.x") }}
@@ -177,6 +177,7 @@ outputs:
     script: build_pkg.sh     # [unix]
     script: build_pkg.bat    # [win]
     build:
+      skip: true  # [blas_impl == 'blis']
       string: {{ build_num }}_h{{ PKG_HASH }}_{{ blas_impl }}
       run_exports:
         - {{ pin_subpackage("liblapacke", max_pin="x.x") }}
@@ -205,7 +206,6 @@ outputs:
         - test -f $PREFIX/lib/liblapacke.so.{{ version_major }}      # [linux]
         - test -f $PREFIX/lib/liblapacke.{{ version_major }}.dylib   # [osx]
         - if not exist %LIBRARY_BIN%/liblapacke.dll exit 1           # [win]
-  {% endif %}
 
   - name: blas-devel
     # uses lapack {{ version }}, not {{ blas_major }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -118,10 +118,11 @@ outputs:
        - blas_{{ blas_impl }}     # [blas_impl != blas_default_impl]
     requirements:
       host:
-        - {{ pin_subpackage("libblas", exact=True) }}
+        # cannot pin exactly due to https://github.com/conda/conda-build/issues/5573
+        - libblas ={{ version }}={{ build_num }}*_{{ blas_impl }}
         - libopenblas *={{ openblas_type }}*    # [win and blas_impl == 'openblas']
       run:
-        - {{ pin_subpackage("libblas", exact=True) }}
+        - libblas ={{ version }}={{ build_num }}*_{{ blas_impl }}
       run_constrained:
         # cannot pin exactly due to https://github.com/conda/conda-build/issues/5572
         - liblapack ={{ version }}={{ build_num }}*_{{ blas_impl }}     # [blas_impl != 'blis']
@@ -225,7 +226,7 @@ outputs:
         - {{ pin_subpackage("libcblas", exact=True) }}       # [blas_impl != 'blis']
         - {{ pin_subpackage("liblapack", exact=True) }}      # [blas_impl != 'blis']
         - {{ pin_subpackage("liblapacke", exact=True) }}     # [blas_impl != 'blis']
-        # don't libblas/libcblas exactly due to issues with exact=True,
+        # don't pin libblas/libcblas exactly due to issues with exact=True,
         # see https://github.com/conda/conda-build/issues/5573
         - libblas    {{ version }} *netlib                   # [blas_impl == 'blis']
         - libcblas   {{ version }} *netlib                   # [blas_impl == 'blis']
@@ -268,7 +269,7 @@ outputs:
         - {{ pin_subpackage("libcblas", exact=True) }}       # [blas_impl != 'blis']
         - {{ pin_subpackage("liblapack", exact=True) }}      # [blas_impl != 'blis']
         - {{ pin_subpackage("liblapacke", exact=True) }}     # [blas_impl != 'blis']
-        # don't libblas/libcblas exactly due to issues with exact=True,
+        # don't pin libblas/libcblas exactly due to issues with exact=True,
         # see https://github.com/conda/conda-build/issues/5573
         - libblas    {{ version }} *netlib                   # [blas_impl == 'blis']
         - libcblas   {{ version }} *netlib                   # [blas_impl == 'blis']

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -82,7 +82,7 @@ outputs:
         - mkl  {{ mkl_version }}                # [blas_impl == 'mkl']
         - libopenblas {{ openblas_version }}    # [blas_impl == 'openblas']
         # on windows we pin exactly, so need to build twice
-        - libopenblas *={{ openblas_type }}*    # [win and blas_impl == 'openblas']
+        - libopenblas =*={{ openblas_type }}*   # [blas_impl == 'openblas' and win]
       run:
         - {{ pin_compatible("libopenblas", max_pin="x.x.x", exact=win) }}  # [blas_impl == 'openblas']
         - {{ pin_compatible("mkl", max_pin="x", exact=win) }}              # [blas_impl == 'mkl']
@@ -125,7 +125,7 @@ outputs:
       host:
         # cannot pin exactly due to https://github.com/conda/conda-build/issues/5573
         - libblas ={{ version }}={{ build_num }}*_{{ blas_impl }}
-        - libopenblas *={{ openblas_type }}*    # [win and blas_impl == 'openblas']
+        - libopenblas =*={{ openblas_type }}*   # [win and blas_impl == 'openblas']
       run:
         - libblas ={{ version }}={{ build_num }}*_{{ blas_impl }}
       run_constrained:
@@ -158,7 +158,7 @@ outputs:
     requirements:
       host:
         - {{ pin_subpackage("libblas", exact=True) }}
-        - libopenblas *={{ openblas_type }}*    # [win and blas_impl == 'openblas']
+        - libopenblas =*={{ openblas_type }}*   # [win and blas_impl == 'openblas']
       run:
         - {{ pin_subpackage("libblas", exact=True) }}
       run_constrained:
@@ -193,7 +193,7 @@ outputs:
         - {{ pin_subpackage("libblas", exact=True) }}
         - {{ pin_subpackage("libcblas", exact=True) }}
         - {{ pin_subpackage("liblapack", exact=True) }}
-        - libopenblas *={{ openblas_type }}*    # [win and blas_impl == 'openblas']
+        - libopenblas =*={{ openblas_type }}*   # [win and blas_impl == 'openblas']
       run:
         - {{ pin_subpackage("libblas", exact=True) }}
         - {{ pin_subpackage("libcblas", exact=True) }}
@@ -222,7 +222,7 @@ outputs:
         - blis      {{ blis_version }}      # [blas_impl == "blis"]
         - mkl-devel {{ mkl_version }}       # [blas_impl == "mkl"]
         - openblas  {{ openblas_version }}  # [blas_impl == "openblas"]
-        - openblas *={{ openblas_type }}*   # [win and blas_impl == 'openblas']
+        - openblas =*={{ openblas_type }}*  # [blas_impl == "openblas" and win]
       run:
         - blis      {{ blis_version }}      # [blas_impl == "blis"]
         - mkl-devel {{ mkl_version }}       # [blas_impl == "mkl"]
@@ -274,7 +274,7 @@ outputs:
         - llvm-openmp   # [linux and ((blas_impl == "openblas") or (blas_impl == "mkl"))]
       host:
         - {{ pin_subpackage("blas-devel", exact=True) }}
-        - openblas *={{ openblas_type }}*   # [win and blas_impl == 'openblas']
+        - openblas =*={{ openblas_type }}*  # [win and blas_impl == 'openblas']
       run:
         - {{ pin_subpackage("blas-devel", exact=True) }}
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -279,7 +279,11 @@ outputs:
         - {{ pin_subpackage("blas-devel", exact=True) }}
     test:
       commands:
-        - echo tested in build script
+        - test -f $PREFIX/lib/liblapacke.so                          # [linux]
+        - test -f $PREFIX/lib/liblapacke.so.{{ version_major }}      # [linux]
+        - test -f $PREFIX/lib/liblapacke.dylib                       # [osx]
+        - test -f $PREFIX/lib/liblapacke.{{ version_major }}.dylib   # [osx]
+        - if not exist %LIBRARY_BIN%/liblapacke.dll exit 1           # [win]
 
 about:
   home: https://github.com/conda-forge/blas-feedstock

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,11 @@
 # for builds across lapack-versions within the same blas_major
 {% set blas_minor = build_num + 100 %}
 
+# versions of pinned blas implementation flavours
+{% set blis_version = "0.9.0" %}
+{% set mkl_version = "2024.2" %}
+{% set openblas_version = "0.3.28" %}
+
 package:
   name: blas-split
   version: "{{ version }}"
@@ -72,12 +77,12 @@ outputs:
         - {{ compiler('fortran') }}   # [blas_impl == 'accelerate']
         - {{ stdlib('c') }}           # [blas_impl == 'accelerate']
       host:
-        - libopenblas 0.3.28   # [blas_impl == 'openblas']
+        - blis {{ blis_version }}               # [blas_impl == 'blis']
+        # from https://github.com/conda-forge/intel_repack-feedstock/
+        - mkl  {{ mkl_version }}                # [blas_impl == 'mkl']
+        - libopenblas {{ openblas_version }}    # [blas_impl == 'openblas']
         # on windows we pin exactly, so need to build twice
         - libopenblas *={{ openblas_type }}*    # [win and blas_impl == 'openblas']
-        # from https://github.com/conda-forge/intel_repack-feedstock/
-        - mkl 2024.2           # [blas_impl == 'mkl']
-        - blis 0.9.0           # [blas_impl == 'blis']
       run:
         - {{ pin_compatible("libopenblas", max_pin="x.x.x", exact=win) }}  # [blas_impl == 'openblas']
         - {{ pin_compatible("mkl", max_pin="x", exact=win) }}              # [blas_impl == 'mkl']
@@ -214,14 +219,14 @@ outputs:
       string: {{ build_num }}_h{{ PKG_HASH }}_{{ blas_impl }}
     requirements:
       host:
-        - openblas   0.3.28  # [blas_impl == "openblas"]
+        - blis      {{ blis_version }}      # [blas_impl == "blis"]
+        - mkl-devel {{ mkl_version }}       # [blas_impl == "mkl"]
+        - openblas  {{ openblas_version }}  # [blas_impl == "openblas"]
         - openblas *={{ openblas_type }}*   # [win and blas_impl == 'openblas']
-        - mkl-devel  2024.2  # [blas_impl == "mkl"]
-        - blis 0.9.0         # [blas_impl == "blis"]
       run:
-        - openblas   0.3.28  # [blas_impl == "openblas"]
-        - mkl-devel  2024.2  # [blas_impl == "mkl"]
-        - blis 0.9.0         # [blas_impl == "blis"]
+        - blis      {{ blis_version }}      # [blas_impl == "blis"]
+        - mkl-devel {{ mkl_version }}       # [blas_impl == "mkl"]
+        - openblas  {{ openblas_version }}  # [blas_impl == "openblas"]
         - {{ pin_subpackage("libblas", exact=True) }}        # [blas_impl != 'blis']
         - {{ pin_subpackage("libcblas", exact=True) }}       # [blas_impl != 'blis']
         - {{ pin_subpackage("liblapack", exact=True) }}      # [blas_impl != 'blis']

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,7 +87,7 @@ outputs:
         - libcblas ={{ version }}={{ build_num }}*_{{ blas_impl }}
         - liblapack ={{ version }}={{ build_num }}*_{{ blas_impl }}     # [blas_impl != 'blis']
         - liblapacke ={{ version }}={{ build_num }}*_{{ blas_impl }}    # [blas_impl != 'blis']
-        - blas * {{ blas_impl }}
+        - blas ={{ blas_major }}.{{ blas_minor }}={{ blas_impl }}
     files:
       - lib/libblas.so                          # [linux]
       - lib/libblas.dylib                       # [osx]
@@ -127,7 +127,7 @@ outputs:
         # cannot pin exactly due to https://github.com/conda/conda-build/issues/5572
         - liblapack ={{ version }}={{ build_num }}*_{{ blas_impl }}     # [blas_impl != 'blis']
         - liblapacke ={{ version }}={{ build_num }}*_{{ blas_impl }}    # [blas_impl != 'blis']
-        - blas * {{ blas_impl }}
+        - blas ={{ blas_major }}.{{ blas_minor }}={{ blas_impl }}
     files:
       - lib/libcblas.so                          # [linux]
       - lib/libcblas.dylib                       # [osx]
@@ -160,7 +160,7 @@ outputs:
         # cannot pin exactly due to https://github.com/conda/conda-build/issues/5572
         - libcblas ={{ version }}={{ build_num }}*_{{ blas_impl }}
         - liblapacke ={{ version }}={{ build_num }}*_{{ blas_impl }}
-        - blas * {{ blas_impl }}
+        - blas ={{ blas_major }}.{{ blas_minor }}={{ blas_impl }}
     files:
       - lib/liblapack.so                          # [linux]
       - lib/liblapack.dylib                       # [osx]
@@ -193,7 +193,7 @@ outputs:
         - {{ pin_subpackage("libcblas", exact=True) }}
         - {{ pin_subpackage("liblapack", exact=True) }}
       run_constrained:
-        - blas * {{ blas_impl }}
+        - blas ={{ blas_major }}.{{ blas_minor }}={{ blas_impl }}
     files:
       - lib/liblapacke.so                          # [linux]
       - lib/liblapacke.dylib                       # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -279,15 +279,16 @@ outputs:
         - liblapacke ={{ version }}=*_netlib                 # [blas_impl == 'blis']
       {% endif %}
       run:
+        - {{ pin_subpackage("blas-devel", exact=True) }}     # [blas_impl != 'blis']
         - {{ pin_subpackage("libblas", exact=True) }}        # [blas_impl != 'blis']
         - {{ pin_subpackage("libcblas", exact=True) }}       # [blas_impl != 'blis']
         - {{ pin_subpackage("liblapack", exact=True) }}      # [blas_impl != 'blis']
         - {{ pin_subpackage("liblapacke", exact=True) }}     # [blas_impl != 'blis']
+        - blas-devel ={{ version }}={{ build_num }}*_blis    # [blas_impl == 'blis']
         - libblas    ={{ version }}={{ build_num }}*_blis    # [blas_impl == 'blis']
         - libcblas   ={{ version }}={{ build_num }}*_blis    # [blas_impl == 'blis']
         - liblapack  ={{ version }}=*_netlib                 # [blas_impl == 'blis']
         - liblapacke ={{ version }}=*_netlib                 # [blas_impl == 'blis']
-        - {{ pin_subpackage("blas-devel", exact=True) }}
     test:
       commands:
         - test -f $PREFIX/lib/liblapacke.so                          # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -273,9 +273,9 @@ outputs:
         - ninja         # [win]
         - llvm-openmp   # [linux and ((blas_impl == "openblas") or (blas_impl == "mkl"))]
       host:
-        - blas-devel {{ version }} {{ build_num }}*_{{ blas_impl }}
+        - blas-devel ={{ version }}={{ build_num }}*_{{ blas_impl }}
       run:
-        - blas-devel {{ version }} {{ build_num }}*_{{ blas_impl }}
+        - blas-devel ={{ version }}={{ build_num }}*_{{ blas_impl }}
     test:
       commands:
         - test -f $PREFIX/lib/liblapacke.so                          # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,9 +83,10 @@ outputs:
         - {{ pin_compatible("mkl", max_pin="x", exact=win) }}              # [blas_impl == 'mkl']
         - {{ pin_compatible("blis", max_pin="x.x.x", exact=win) }}         # [blas_impl == 'blis']
       run_constrained:
-        - {{ pin_subpackage("libcblas", exact=True) }}
-        - {{ pin_subpackage("liblapack", exact=True) }}    # [blas_impl != 'blis']
-        - {{ pin_subpackage("liblapacke", exact=True) }}   # [blas_impl != 'blis']
+        # cannot pin exactly due to https://github.com/conda/conda-build/issues/5572
+        - libcblas ={{ version }}={{ build_num }}*_{{ blas_impl }}
+        - liblapack ={{ version }}={{ build_num }}*_{{ blas_impl }}     # [blas_impl != 'blis']
+        - liblapacke ={{ version }}={{ build_num }}*_{{ blas_impl }}    # [blas_impl != 'blis']
         - blas * {{ blas_impl }}
     files:
       - lib/libblas.so                          # [linux]
@@ -122,8 +123,9 @@ outputs:
       run:
         - {{ pin_subpackage("libblas", exact=True) }}
       run_constrained:
-        - {{ pin_subpackage("liblapack", exact=True) }}    # [blas_impl != 'blis']
-        - {{ pin_subpackage("liblapacke", exact=True) }}   # [blas_impl != 'blis']
+        # cannot pin exactly due to https://github.com/conda/conda-build/issues/5572
+        - liblapack ={{ version }}={{ build_num }}*_{{ blas_impl }}     # [blas_impl != 'blis']
+        - liblapacke ={{ version }}={{ build_num }}*_{{ blas_impl }}    # [blas_impl != 'blis']
         - blas * {{ blas_impl }}
     files:
       - lib/libcblas.so                          # [linux]
@@ -154,8 +156,9 @@ outputs:
       run:
         - {{ pin_subpackage("libblas", exact=True) }}
       run_constrained:
-        - {{ pin_subpackage("libcblas", exact=True) }}
-        - {{ pin_subpackage("liblapacke", exact=True) }}
+        # cannot pin exactly due to https://github.com/conda/conda-build/issues/5572
+        - libcblas ={{ version }}={{ build_num }}*_{{ blas_impl }}
+        - liblapacke ={{ version }}={{ build_num }}*_{{ blas_impl }}
         - blas * {{ blas_impl }}
     files:
       - lib/liblapack.so                          # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -228,10 +228,11 @@ outputs:
         - {{ pin_subpackage("liblapacke", exact=True) }}     # [blas_impl != 'blis']
         # don't pin libblas/libcblas exactly due to issues with exact=True,
         # see https://github.com/conda/conda-build/issues/5573
-        - libblas    {{ version }} *netlib                   # [blas_impl == 'blis']
-        - libcblas   {{ version }} *netlib                   # [blas_impl == 'blis']
-        - liblapack  {{ version }} *netlib                   # [blas_impl == 'blis']
-        - liblapacke {{ version }} *netlib                   # [blas_impl == 'blis']
+        - libblas    ={{ version }}={{ build_num }}*_blis    # [blas_impl == 'blis']
+        - libcblas   ={{ version }}={{ build_num }}*_blis    # [blas_impl == 'blis']
+        # netlib variants don't have the same build number
+        - liblapack  ={{ version }}=*_netlib                 # [blas_impl == 'blis']
+        - liblapacke ={{ version }}=*_netlib                 # [blas_impl == 'blis']
     test:
       commands:
         - test -f $PREFIX/lib/pkgconfig/blas.pc                     # [unix and blas_impl == "openblas"]
@@ -271,20 +272,21 @@ outputs:
         - {{ pin_subpackage("liblapacke", exact=True) }}     # [blas_impl != 'blis']
         # don't pin libblas/libcblas exactly due to issues with exact=True,
         # see https://github.com/conda/conda-build/issues/5573
-        - libblas    {{ version }} *netlib                   # [blas_impl == 'blis']
-        - libcblas   {{ version }} *netlib                   # [blas_impl == 'blis']
-        - liblapack  {{ version }} *netlib                   # [blas_impl == 'blis']
-        - liblapacke {{ version }} *netlib                   # [blas_impl == 'blis']
+        - libblas    ={{ version }}={{ build_num }}*_blis    # [blas_impl == 'blis']
+        - libcblas   ={{ version }}={{ build_num }}*_blis    # [blas_impl == 'blis']
+        # netlib variants don't have the same build number
+        - liblapack  ={{ version }}=*_netlib                 # [blas_impl == 'blis']
+        - liblapacke ={{ version }}=*_netlib                 # [blas_impl == 'blis']
       {% endif %}
       run:
         - {{ pin_subpackage("libblas", exact=True) }}        # [blas_impl != 'blis']
         - {{ pin_subpackage("libcblas", exact=True) }}       # [blas_impl != 'blis']
         - {{ pin_subpackage("liblapack", exact=True) }}      # [blas_impl != 'blis']
         - {{ pin_subpackage("liblapacke", exact=True) }}     # [blas_impl != 'blis']
-        - libblas    {{ version }} *netlib                   # [blas_impl == 'blis']
-        - libcblas   {{ version }} *netlib                   # [blas_impl == 'blis']
-        - liblapack  {{ version }} *netlib                   # [blas_impl == 'blis']
-        - liblapacke {{ version }} *netlib                   # [blas_impl == 'blis']
+        - libblas    ={{ version }}={{ build_num }}*_blis    # [blas_impl == 'blis']
+        - libcblas   ={{ version }}={{ build_num }}*_blis    # [blas_impl == 'blis']
+        - liblapack  ={{ version }}=*_netlib                 # [blas_impl == 'blis']
+        - liblapacke ={{ version }}=*_netlib                 # [blas_impl == 'blis']
         - {{ pin_subpackage("blas-devel", exact=True) }}
     test:
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -215,9 +215,11 @@ outputs:
         - openblas   0.3.28  # [blas_impl == "openblas"]
         - openblas *={{ openblas_type }}*   # [win and blas_impl == 'openblas']
         - mkl-devel  2024.2  # [blas_impl == "mkl"]
+        - blis 0.9.0         # [blas_impl == "blis"]
       run:
         - openblas   0.3.28  # [blas_impl == "openblas"]
         - mkl-devel  2024.2  # [blas_impl == "mkl"]
+        - blis 0.9.0         # [blas_impl == "blis"]
         - {{ pin_subpackage("liblapack", exact=True) }}      # [blas_impl != 'blis']
         - {{ pin_subpackage("liblapacke", exact=True) }}     # [blas_impl != 'blis']
         - liblapack  {{ version }} *netlib                   # [blas_impl == 'blis']
@@ -249,23 +251,20 @@ outputs:
         - ninja         # [win]
         - llvm-openmp   # [linux and ((blas_impl == "openblas") or (blas_impl == "mkl"))]
       host:
-      # Building with blis fails due to a conda-build bug
-      {% if blas_impl != 'blis' %}
-        - {{ pin_subpackage("liblapack", exact=True) }}
-        - {{ pin_subpackage("liblapacke", exact=True) }}
-        - {{ pin_subpackage("libcblas", exact=True) }}
-        - {{ pin_subpackage("libblas", exact=True) }}
         - openblas *={{ openblas_type }}*   # [win and blas_impl == 'openblas']
-      {% else %}
-        - blis 0.9.0
-      {% endif %}
-      run:
+        - {{ pin_subpackage("libblas", exact=True) }}
+        - {{ pin_subpackage("libcblas", exact=True) }}
         - {{ pin_subpackage("liblapack", exact=True) }}      # [blas_impl != 'blis']
         - {{ pin_subpackage("liblapacke", exact=True) }}     # [blas_impl != 'blis']
         - liblapack  {{ version }} *netlib                   # [blas_impl == 'blis']
         - liblapacke {{ version }} *netlib                   # [blas_impl == 'blis']
-        - {{ pin_subpackage("libcblas", exact=True) }}
+      run:
         - {{ pin_subpackage("libblas", exact=True) }}
+        - {{ pin_subpackage("libcblas", exact=True) }}
+        - {{ pin_subpackage("liblapack", exact=True) }}      # [blas_impl != 'blis']
+        - {{ pin_subpackage("liblapacke", exact=True) }}     # [blas_impl != 'blis']
+        - liblapack  {{ version }} *netlib                   # [blas_impl == 'blis']
+        - liblapacke {{ version }} *netlib                   # [blas_impl == 'blis']
         - {{ pin_subpackage("blas-devel", exact=True) }}
     test:
       commands:

--- a/recipe/test_blas.sh
+++ b/recipe/test_blas.sh
@@ -9,11 +9,6 @@ cd build
 
 SKIP_TESTS="dummy"
 
-if [[ "${blas_impl}" == "blis" ]]; then
-  # conda-build can't install a correct environment for testing
-  conda install -c conda-forge "libblas=*=*blis" "libcblas=*=*blis" "liblapack=*=*netlib" "liblapacke=*=*netlib" --use-local --yes -p $PREFIX
-fi
-
 if [[ "$target_platform" != osx-* ]]; then
   ulimit -s unlimited
 fi


### PR DESCRIPTION
This combines two PRs, where one doesn't work (or make much sense) without the other.

Mainly I wanted to do #129, which is a follow-up to #126, which however runs into a bunch of conda-build bugs (https://github.com/conda/conda-build/issues/5571, https://github.com/conda/conda-build/issues/5572).

The other (#115) is for removing a very long-standing workaround for an unspecified conda-build bug that goes back forever (https://github.com/conda-forge/blas-feedstock/commit/f9b54a03c2ba5b9607f8d7ebcc40685a07c84d9d), but which doesn't seem to trigger anymore with 24.11.

The hope is that #129 + #115 passes, where #129 alone is currently stuck

Closes #129 
Closes #115