### PR TITLE
Revert "use ="

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -273,9 +273,9 @@ outputs:
         - ninja         # [win]
         - llvm-openmp   # [linux and ((blas_impl == "openblas") or (blas_impl == "mkl"))]
       host:
-        - blas-devel ={{ version }}={{ build_num }}*_{{ blas_impl }}
+        - blas-devel {{ version }} {{ build_num }}*_{{ blas_impl }}
       run:
-        - blas-devel ={{ version }}={{ build_num }}*_{{ blas_impl }}
+        - blas-devel {{ version }} {{ build_num }}*_{{ blas_impl }}
     test:
       commands:
         - test -f $PREFIX/lib/liblapacke.so                          # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -82,7 +82,7 @@ outputs:
         - mkl  {{ mkl_version }}                # [blas_impl == 'mkl']
         - libopenblas {{ openblas_version }}    # [blas_impl == 'openblas']
         # on windows we pin exactly, so need to build twice
-        - libopenblas =*={{ openblas_type }}*   # [win and blas_impl == 'openblas']
+        - libopenblas * {{ openblas_type }}*    # [win and blas_impl == 'openblas']
         - llvm-openmp                           # [win and openblas_type == 'openmp']
       run:
         - {{ pin_compatible("libopenblas", max_pin="x.x.x", exact=win) }}  # [blas_impl == 'openblas']
@@ -90,10 +90,10 @@ outputs:
         - {{ pin_compatible("blis", max_pin="x.x.x", exact=win) }}         # [blas_impl == 'blis']
       run_constrained:
         # cannot pin exactly due to https://github.com/conda/conda-build/issues/5572
-        - libcblas ={{ version }}={{ build_num }}*_{{ blas_impl }}
-        - liblapack ={{ version }}={{ build_num }}*_{{ blas_impl }}     # [blas_impl != 'blis']
-        - liblapacke ={{ version }}={{ build_num }}*_{{ blas_impl }}    # [blas_impl != 'blis']
-        - blas ={{ blas_major }}.{{ blas_minor }}={{ blas_impl }}
+        - libcblas {{ version }} {{ build_num }}*_{{ blas_impl }}
+        - liblapack {{ version }} {{ build_num }}*_{{ blas_impl }}     # [blas_impl != 'blis']
+        - liblapacke {{ version }} {{ build_num }}*_{{ blas_impl }}    # [blas_impl != 'blis']
+        - blas {{ blas_major }}.{{ blas_minor }} {{ blas_impl }}
     files:
       - lib/libblas.so                          # [linux]
       - lib/libblas.dylib                       # [osx]
@@ -125,16 +125,16 @@ outputs:
     requirements:
       host:
         # cannot pin exactly due to https://github.com/conda/conda-build/issues/5573
-        - libblas ={{ version }}={{ build_num }}*_{{ blas_impl }}
-        - libopenblas =*={{ openblas_type }}*   # [win and blas_impl == 'openblas']
+        - libblas {{ version }} {{ build_num }}*_{{ blas_impl }}
+        - libopenblas * {{ openblas_type }}*    # [win and blas_impl == 'openblas']
         - llvm-openmp                           # [win and openblas_type == 'openmp']
       run:
-        - libblas ={{ version }}={{ build_num }}*_{{ blas_impl }}
+        - libblas {{ version }} {{ build_num }}*_{{ blas_impl }}
       run_constrained:
         # cannot pin exactly due to https://github.com/conda/conda-build/issues/5572
-        - liblapack ={{ version }}={{ build_num }}*_{{ blas_impl }}     # [blas_impl != 'blis']
-        - liblapacke ={{ version }}={{ build_num }}*_{{ blas_impl }}    # [blas_impl != 'blis']
-        - blas ={{ blas_major }}.{{ blas_minor }}={{ blas_impl }}
+        - liblapack {{ version }} {{ build_num }}*_{{ blas_impl }}     # [blas_impl != 'blis']
+        - liblapacke {{ version }} {{ build_num }}*_{{ blas_impl }}    # [blas_impl != 'blis']
+        - blas {{ blas_major }}.{{ blas_minor }} {{ blas_impl }}
     files:
       - lib/libcblas.so                          # [linux]
       - lib/libcblas.dylib                       # [osx]
@@ -160,15 +160,15 @@ outputs:
     requirements:
       host:
         - {{ pin_subpackage("libblas", exact=True) }}
-        - libopenblas =*={{ openblas_type }}*   # [win and blas_impl == 'openblas']
+        - libopenblas * {{ openblas_type }}*    # [win and blas_impl == 'openblas']
         - llvm-openmp                           # [win and openblas_type == 'openmp']
       run:
         - {{ pin_subpackage("libblas", exact=True) }}
       run_constrained:
         # cannot pin exactly due to https://github.com/conda/conda-build/issues/5572
-        - libcblas ={{ version }}={{ build_num }}*_{{ blas_impl }}
-        - liblapacke ={{ version }}={{ build_num }}*_{{ blas_impl }}
-        - blas ={{ blas_major }}.{{ blas_minor }}={{ blas_impl }}
+        - libcblas {{ version }} {{ build_num }}*_{{ blas_impl }}
+        - liblapacke {{ version }} {{ build_num }}*_{{ blas_impl }}
+        - blas {{ blas_major }}.{{ blas_minor }} {{ blas_impl }}
     files:
       - lib/liblapack.so                          # [linux]
       - lib/liblapack.dylib                       # [osx]
@@ -196,14 +196,14 @@ outputs:
         - {{ pin_subpackage("libblas", exact=True) }}
         - {{ pin_subpackage("libcblas", exact=True) }}
         - {{ pin_subpackage("liblapack", exact=True) }}
-        - libopenblas =*={{ openblas_type }}*   # [win and blas_impl == 'openblas']
+        - libopenblas * {{ openblas_type }}*    # [win and blas_impl == 'openblas']
         - llvm-openmp                           # [win and openblas_type == 'openmp']
       run:
         - {{ pin_subpackage("libblas", exact=True) }}
         - {{ pin_subpackage("libcblas", exact=True) }}
         - {{ pin_subpackage("liblapack", exact=True) }}
       run_constrained:
-        - blas ={{ blas_major }}.{{ blas_minor }}={{ blas_impl }}
+        - blas {{ blas_major }}.{{ blas_minor }} {{ blas_impl }}
     files:
       - lib/liblapacke.so                          # [linux]
       - lib/liblapacke.dylib                       # [osx]
@@ -226,7 +226,7 @@ outputs:
         - blis      {{ blis_version }}      # [blas_impl == "blis"]
         - mkl-devel {{ mkl_version }}       # [blas_impl == "mkl"]
         - openblas  {{ openblas_version }}  # [blas_impl == "openblas"]
-        - openblas =*={{ openblas_type }}*  # [blas_impl == "openblas" and win]
+        - openblas * {{ openblas_type }}*   # [blas_impl == "openblas" and win]
       run:
         - blis      {{ blis_version }}      # [blas_impl == "blis"]
         - mkl-devel {{ mkl_version }}       # [blas_impl == "mkl"]
@@ -236,8 +236,8 @@ outputs:
         - {{ pin_subpackage("liblapack", exact=True) }}      # [blas_impl != 'blis']
         - {{ pin_subpackage("liblapacke", exact=True) }}     # [blas_impl != 'blis']
         # netlib variants don't have the same build number
-        - liblapack  ={{ version }}=*_netlib                 # [blas_impl == 'blis']
-        - liblapacke ={{ version }}=*_netlib                 # [blas_impl == 'blis']
+        - liblapack  {{ version }} *_netlib                  # [blas_impl == 'blis']
+        - liblapacke {{ version }} *_netlib                  # [blas_impl == 'blis']
     test:
       commands:
         - test -f $PREFIX/lib/pkgconfig/blas.pc                     # [unix and blas_impl == "openblas"]


### PR DESCRIPTION
This reverts commit f0d0ed446f7715c72fe1ab37d22f866552925ba9.

Re-test another weird interaction between `=` and match specs that was observed in #129 