### PR TITLE
add cap for MKL version across all flavours to avoid solver thrashing

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -90,7 +90,7 @@ outputs:
         - libopenblas =*={{ openblas_type }}*   # [win and blas_impl == 'openblas']
         - llvm-openmp                           # [win and openblas_type == 'openmp']
         # for run-export across all flavours, see comment at the top
-        - mkl-devel {{ mkl_version }}           # [x86_64]
+        - mkl-devel {{ mkl_version }}           # [x86_64 and not osx]
       run:
         - {{ pin_compatible("blis", max_pin="x.x.x", exact=win) }}         # [blas_impl == 'blis']
         - {{ pin_compatible("mkl", max_pin="x", exact=win) }}              # [blas_impl == 'mkl']
@@ -138,7 +138,7 @@ outputs:
         - libopenblas =*={{ openblas_type }}*   # [win and blas_impl == 'openblas']
         - llvm-openmp                           # [win and openblas_type == 'openmp']
         # for run-export across all flavours, see comment at the top
-        - mkl-devel {{ mkl_version }}           # [x86_64]
+        - mkl-devel {{ mkl_version }}           # [x86_64 and not osx]
       run:
         - {{ pin_subpackage("libblas", exact=True) }}
         - libopenblas =*={{ openblas_type }}*   # [win and blas_impl == 'openblas']
@@ -175,7 +175,7 @@ outputs:
         - libopenblas =*={{ openblas_type }}*   # [win and blas_impl == 'openblas']
         - llvm-openmp                           # [win and openblas_type == 'openmp']
         # for run-export across all flavours, see comment at the top
-        - mkl-devel {{ mkl_version }}           # [x86_64]
+        - mkl-devel {{ mkl_version }}           # [x86_64 and not osx]
       run:
         - {{ pin_subpackage("libblas", exact=True) }}
         - libopenblas =*={{ openblas_type }}*   # [win and blas_impl == 'openblas']
@@ -214,7 +214,7 @@ outputs:
         - libopenblas =*={{ openblas_type }}*   # [win and blas_impl == 'openblas']
         - llvm-openmp                           # [win and openblas_type == 'openmp']
         # for run-export across all flavours, see comment at the top
-        - mkl-devel {{ mkl_version }}           # [x86_64]
+        - mkl-devel {{ mkl_version }}           # [x86_64 and not osx]
       run:
         - {{ pin_subpackage("libblas", exact=True) }}
         - {{ pin_subpackage("libcblas", exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "3.9.0" %}
 # if build_num is reset to 0 (for new version), update increment for blas_minor below
-{% set build_num = 28 %}
+{% set build_num = 29 %}
 {% set version_major = version.split(".")[0] %}
 # blas_major denotes major infrastructural change to how blas is managed
 {% set blas_major = "2" %}
@@ -12,6 +12,12 @@
 {% set blis_version = "0.9.0" %}
 {% set mkl_version = "2024.2" %}
 {% set openblas_version = "0.3.28" %}
+# MKL uses the yyyy-portion of CalVer also as the major version indicating API/ABI stability, see
+# https://github.com/conda-forge/intel_repack-feedstock/issues/81
+# to avoid tempting the solver into switching the underlying blas flavour "just" to update MKL,
+# we add a constraint on the MKL-version across all flavours. This means (essentially) that any
+# new MKL major version must first pass the tests on this feedstock
+{% set mkl_next = mkl_version.split(".")[0]|int + 1 %}
 
 package:
   name: blas-split
@@ -96,6 +102,8 @@ outputs:
         - liblapack ={{ version }}={{ build_num }}*_{{ blas_impl }}     # [blas_impl != 'blis']
         - liblapacke ={{ version }}={{ build_num }}*_{{ blas_impl }}    # [blas_impl != 'blis']
         - blas ={{ blas_major }}.{{ blas_minor }}={{ blas_impl }}
+        # see comment at the top
+        - mkl <{{ mkl_next }}
     files:
       - lib/libblas.so                          # [linux]
       - lib/libblas.dylib                       # [osx]
@@ -138,6 +146,7 @@ outputs:
         - liblapack ={{ version }}={{ build_num }}*_{{ blas_impl }}     # [blas_impl != 'blis']
         - liblapacke ={{ version }}={{ build_num }}*_{{ blas_impl }}    # [blas_impl != 'blis']
         - blas ={{ blas_major }}.{{ blas_minor }}={{ blas_impl }}
+        - mkl <{{ mkl_next }}
     files:
       - lib/libcblas.so                          # [linux]
       - lib/libcblas.dylib                       # [osx]
@@ -173,6 +182,7 @@ outputs:
         - libcblas ={{ version }}={{ build_num }}*_{{ blas_impl }}
         - liblapacke ={{ version }}={{ build_num }}*_{{ blas_impl }}
         - blas ={{ blas_major }}.{{ blas_minor }}={{ blas_impl }}
+        - mkl <{{ mkl_next }}
     files:
       - lib/liblapack.so                          # [linux]
       - lib/liblapack.dylib                       # [osx]
@@ -209,6 +219,7 @@ outputs:
         - libopenblas =*={{ openblas_type }}*   # [win and blas_impl == 'openblas']
       run_constrained:
         - blas ={{ blas_major }}.{{ blas_minor }}={{ blas_impl }}
+        - mkl <{{ mkl_next }}
     files:
       - lib/liblapacke.so                          # [linux]
       - lib/liblapacke.dylib                       # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,6 @@
 # to avoid tempting the solver into switching the underlying blas flavour "just" to update MKL,
 # we add a constraint on the MKL-version across all flavours. This means (essentially) that any
 # new MKL major version must first pass the tests on this feedstock
-{% set mkl_next = mkl_version.split(".")[0]|int + 1 %}
 
 package:
   name: blas-split
@@ -90,6 +89,8 @@ outputs:
         # on windows we pin exactly, so need to build twice
         - libopenblas =*={{ openblas_type }}*   # [win and blas_impl == 'openblas']
         - llvm-openmp                           # [win and openblas_type == 'openmp']
+        # for run-export across all flavours, see comment at the top
+        - mkl-devel {{ mkl_version }}           # [x86_64]
       run:
         - {{ pin_compatible("blis", max_pin="x.x.x", exact=win) }}         # [blas_impl == 'blis']
         - {{ pin_compatible("mkl", max_pin="x", exact=win) }}              # [blas_impl == 'mkl']
@@ -102,8 +103,6 @@ outputs:
         - liblapack ={{ version }}={{ build_num }}*_{{ blas_impl }}     # [blas_impl != 'blis']
         - liblapacke ={{ version }}={{ build_num }}*_{{ blas_impl }}    # [blas_impl != 'blis']
         - blas ={{ blas_major }}.{{ blas_minor }}={{ blas_impl }}
-        # see comment at the top
-        - mkl <{{ mkl_next }}
     files:
       - lib/libblas.so                          # [linux]
       - lib/libblas.dylib                       # [osx]
@@ -138,6 +137,8 @@ outputs:
         - libblas ={{ version }}={{ build_num }}*_{{ blas_impl }}
         - libopenblas =*={{ openblas_type }}*   # [win and blas_impl == 'openblas']
         - llvm-openmp                           # [win and openblas_type == 'openmp']
+        # for run-export across all flavours, see comment at the top
+        - mkl-devel {{ mkl_version }}           # [x86_64]
       run:
         - {{ pin_subpackage("libblas", exact=True) }}
         - libopenblas =*={{ openblas_type }}*   # [win and blas_impl == 'openblas']
@@ -146,7 +147,6 @@ outputs:
         - liblapack ={{ version }}={{ build_num }}*_{{ blas_impl }}     # [blas_impl != 'blis']
         - liblapacke ={{ version }}={{ build_num }}*_{{ blas_impl }}    # [blas_impl != 'blis']
         - blas ={{ blas_major }}.{{ blas_minor }}={{ blas_impl }}
-        - mkl <{{ mkl_next }}
     files:
       - lib/libcblas.so                          # [linux]
       - lib/libcblas.dylib                       # [osx]
@@ -174,6 +174,8 @@ outputs:
         - {{ pin_subpackage("libblas", exact=True) }}
         - libopenblas =*={{ openblas_type }}*   # [win and blas_impl == 'openblas']
         - llvm-openmp                           # [win and openblas_type == 'openmp']
+        # for run-export across all flavours, see comment at the top
+        - mkl-devel {{ mkl_version }}           # [x86_64]
       run:
         - {{ pin_subpackage("libblas", exact=True) }}
         - libopenblas =*={{ openblas_type }}*   # [win and blas_impl == 'openblas']
@@ -182,7 +184,6 @@ outputs:
         - libcblas ={{ version }}={{ build_num }}*_{{ blas_impl }}
         - liblapacke ={{ version }}={{ build_num }}*_{{ blas_impl }}
         - blas ={{ blas_major }}.{{ blas_minor }}={{ blas_impl }}
-        - mkl <{{ mkl_next }}
     files:
       - lib/liblapack.so                          # [linux]
       - lib/liblapack.dylib                       # [osx]
@@ -212,6 +213,8 @@ outputs:
         - {{ pin_subpackage("liblapack", exact=True) }}
         - libopenblas =*={{ openblas_type }}*   # [win and blas_impl == 'openblas']
         - llvm-openmp                           # [win and openblas_type == 'openmp']
+        # for run-export across all flavours, see comment at the top
+        - mkl-devel {{ mkl_version }}           # [x86_64]
       run:
         - {{ pin_subpackage("libblas", exact=True) }}
         - {{ pin_subpackage("libcblas", exact=True) }}
@@ -219,7 +222,6 @@ outputs:
         - libopenblas =*={{ openblas_type }}*   # [win and blas_impl == 'openblas']
       run_constrained:
         - blas ={{ blas_major }}.{{ blas_minor }}={{ blas_impl }}
-        - mkl <{{ mkl_next }}
     files:
       - lib/liblapacke.so                          # [linux]
       - lib/liblapacke.dylib                       # [osx]


### PR DESCRIPTION
The blas metapackage here handles the BLAS/LAPACK flavour globally across an end-user's environment, but from the POV of the solver, it's just another version to maximize. And if there are several contradictory possibilities on which package to choose to optimize, new MKL versions will often push the solver to _ignore_ the flavour here, and maximize the MKL version _at the expense_ of switching the entire blas flavour of the environment, which is counter-intuitive and undesired from the POV of the users:
```diff
- libblas                            3.9.0  25_win64_mkl           conda-forge        4MB
+ libblas                            3.9.0  25_win64_openblas      conda-forge        4MB
- libcblas                           3.9.0  25_win64_mkl           conda-forge        4MB
+ libcblas                           3.9.0  25_win64_openblas      conda-forge        4MB
- liblapack                          3.9.0  25_win64_mkl           conda-forge        4MB
+ liblapack                          3.9.0  25_win64_openblas      conda-forge        4MB
```
This is mainly relevant on windows (where we default to MKL), but obviously it affects all x64 architectures that want to use MKL.

So to avoid the temptation for the solver in wrongly updating MKL and inadvertently switching the flavour, add a cap for MKL across all flavours. This will help, because we're currently in just such a situation as explained above, due to https://github.com/conda-forge/intel_repack-feedstock/issues/83, which is blocking #128.

We will likewise need to repodata patch this constraint into old blas builds, because otherwise the solver will just select an older build.

What this means going forward is that new MKL major versions can still be published as usual on https://github.com/conda-forge/intel_repack-feedstock, but it will actually require a PR on this feedstock to enable a new MKL major version in a way that becomes co-installable with other packages depending on the shared blas infrastructure. This is fully aligned with the fact that MKL uses a mix of SemVer and CalVer (or rather: both simultaneously), see https://github.com/conda-forge/intel_repack-feedstock/issues/81.

PTAL @conda-forge/blas 

CC @conda-forge/intel_repack 