### PR TITLE
weigh down non-default blas with an extra feature

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "3.9.0" %}
 # if build_num is reset to 0 (for new version), update increment for blas_minor below
-{% set build_num = 36 %}
+{% set build_num = 37 %}
 {% set version_major = version.split(".")[0] %}
 # blas_major denotes major infrastructural change to how blas is managed
 {% set blas_major = "2" %}
@@ -82,6 +82,7 @@ outputs:
         - {{ pin_subpackage("libblas", max_pin="x") }}
       track_features:
        - blas_{{ blas_impl }}  # [blas_impl != blas_default_impl]
+       - blas_{{ blas_impl }}_2  # [blas_impl != blas_default_impl]
     requirements:
       build:
         - {{ compiler('fortran') }}   # [blas_impl in ('accelerate', 'newaccelerate')]


### PR DESCRIPTION
Currently, blas implementations other than openblas are weighed down by a single feature in this `blas` package.

openblas openmp is [_also_ weighed down by a feature](https://github.com/conda-forge/openblas-feedstock/blob/e6f0e353c27f5b3073ca15e6fe8e67d6ef8a55ab/recipe/meta.yaml#L47-L53), putting it at the same weight as all other non-default implementations. Since the openmp build is sometimes _required_ (e.g. by mumps because calling blas from openmp means openblas _must_ be built with openmp), the default blas sometimes has the same feature weight as all the others (1).

The result is a valid solution is picking nvpl  by default on linux-aarch64, as is done today by pixi (mamba picks openblas-openmp, but both have the same feature weight, so I think the solution is ambiguous),  or mkl on linux-64, etc.

I think the requirement should be that any blas implementation other than openblas needs to have more features than _any_ openblas build, which today means at least two. This was previously done just for netlib in https://github.com/conda-forge/lapack-feedstock/pull/71 but I think maybe it needs to be done across the board here, as well.

This was previously handled specifically for netlib in https://github.com/conda-forge/lapack-feedstock/pull/71, but I think it should maybe happen on _this_ package as well, to ensure that non-default blas always weighs more than openblas, even when openblas-openmp is the only openblas candidate.

Current weights:

- openblas (default openmp): 0
- openblas (non-default openmp): 1
- most other blas: 1
- netlib: 2

With this PR, we'd have this priority:

- openblas (default openmp): 0
- openblas (non-default openmp): 1
- all(?) other blas: 2

If we want to keep netlib weighted below other non-default blas, we'd need to do https://github.com/conda-forge/lapack-feedstock/pull/71 and https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/860 again to get netlib weight to 3.

An alternative (and much simpler) fix is removing the feature from openblas-openmp: https://github.com/conda-forge/openblas-feedstock/pull/164 which puts openmp and non-openmp openblas at the same feature weight (0). If a priority is needed, perhaps build offset would be less severe. Advantage of this: no repodata patches really needed, as future builds would appropriatly prioritize latest openblas-openmp above non-default blas.

Related issues and PRs:

- https://github.com/conda-forge/scipy-feedstock/issues/310
- https://github.com/conda-forge/openblas-feedstock/pull/164
- https://github.com/conda-forge/lapack-feedstock/pull/71
- https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/860
- https://github.com/conda-forge/mumps-feedstock/pull/126
